### PR TITLE
Add Ballet Bots curriculum documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ This documentation is organized into the following sections:
   - **[Memory Tool](./tools/memory.md):** Documentation for the `save_memory` tool.
 - **Examples:**
   - **[Vertex AI Search integration](./examples/vertex-ai-search.md):** Step-by-step guidance for connecting Gemini CLI agents to Vertex AI Search.
+  - **[IntuitionLabs Ballet Bots curriculum assets](./intuitionlabs/README.md):** Reference materials for an arts-and-robotics learning program that leverages Gemini CLI for content generation.
 - **[Contributing & Development Guide](../CONTRIBUTING.md):** Information for contributors and developers, including setup, building, testing, and coding conventions.
 - **[NPM](./npm.md):** Details on how the project's packages are structured
 - **[Troubleshooting Guide](./troubleshooting.md):** Find solutions to common problems and FAQs.

--- a/docs/intuitionlabs/README.md
+++ b/docs/intuitionlabs/README.md
@@ -1,0 +1,14 @@
+# IntuitionLabs Ballet Bots Curriculum Assets
+
+The IntuitionLabs Ballet Bots program combines creative movement, robotics, and beginner-friendly coding to help learners explore STEAM concepts through embodied practice. This directory curates reference material for facilitators who want to adapt the experience or build complementary tooling with Gemini CLI.
+
+## Directory structure
+
+- `class_overviews/`
+  - [`ballet_bots.md`](./class_overviews/ballet_bots.md): Curriculum goals, narrative arc, and module breakdown.
+  - [`minting_system_overview.md`](./class_overviews/minting_system_overview.md): Token and badge mechanics that reward learner progress.
+- `teaching_materials/`
+  - [`lesson_plans.md`](./teaching_materials/lesson_plans.md): Ready-to-run outlines for each session.
+  - [`student_worksheets.md`](./teaching_materials/student_worksheets.md): Printable activities and reflection prompts.
+
+Use these materials alongside Gemini CLI to generate custom prompts, adapt activities to new audiences, or manage interactive assets referenced by the curriculum.

--- a/docs/intuitionlabs/class_overviews/ballet_bots.md
+++ b/docs/intuitionlabs/class_overviews/ballet_bots.md
@@ -1,0 +1,48 @@
+# Ballet Bots Program Overview
+
+The Ballet Bots curriculum blends creative dance, robotics, and introductory coding. Learners personify programmable robots through choreography challenges, gradually shifting from guided sequences to self-directed storytelling. The program is optimized for middle-school makerspaces but can be adapted for camps, after-school sessions, or community labs.
+
+## Learning goals
+
+- **Embodied computational thinking:** Translate dance patterns into reusable algorithms and debugging steps.
+- **Creative robotics literacy:** Prototype motion routines with block-based code before transferring them to physical robots.
+- **Collaboration and critique:** Share choreographed pieces, practice giving actionable feedback, and iterate on performances.
+- **Wellness and confidence:** Encourage joyful movement, stage presence, and peer support in a low-stakes environment.
+
+## Participant profile
+
+- Ages 10–14 with curiosity about coding, robotics, or dance.
+- No prior programming experience required.
+- Works best with groups of 12–20 and a facilitator-to-student ratio of 1:6.
+
+## Curriculum arc
+
+| Module | Theme | Core Activities | Competencies |
+| --- | --- | --- | --- |
+| 1. Welcome to Ballet Bots | Story primer, movement warmups | Icebreaker choreography, robotics story world introduction, robotics safety walkthrough | Storytelling, body awareness |
+| 2. Coding Motions | Mapping moves to instructions | Blockly-style sequencer challenges, tempo experiments, debugging relay | Sequencing, loops, conditional thinking |
+| 3. Sensors & Expression | Responsive performance | Investigate distance/light sensors, design call-and-response routines, emotion cue mapping | Inputs/outputs, empathetic design |
+| 4. Collaborative Composition | Team choreography | Group storyboards, role-based planning, rehearsal rotations, constructive critique | Collaboration, iteration |
+| 5. Showcase Build | Production and polish | Lighting/audio integration, costume prototyping, timed run-throughs | Project management, performance readiness |
+| 6. Community Performance | Share with audience | Final performance, reflection circle, badge minting | Reflection, celebration |
+
+## Assessment strategy
+
+- **Formative checkpoints:** Quick gallery walks, debugging stand-ups, and peer feedback rubrics at the end of each module.
+- **Showcase rubric:** Criteria for story clarity, technical execution, collaboration, and creativity inform final badge awards.
+- **Learner reflections:** Journaling prompts connect emotions to problem-solving, encouraging growth mindset framing.
+
+## Materials & technology
+
+- Laptop or tablet per team with block-based coding interface (e.g., Scratch, MakeCode).
+- Two to three programmable robots (Sphero, Cue, or similar) per small group.
+- Bluetooth speakers for music cues and sound design experiments.
+- Performance props: scarves, LED accessories, lightweight costume materials.
+- Optional: projection system for visuals, stage lighting kit.
+
+## Facilitator notes
+
+- Integrate short stretch breaks to maintain energy and reduce screen fatigue.
+- Encourage learners to narrate their code aloud; this bridges movement vocabulary with algorithmic thinking.
+- Use video capture for rehearsals so teams can review and iterate asynchronously.
+- Pair shy movers with confident choreographers to build mutual support and balanced skill exchange.

--- a/docs/intuitionlabs/class_overviews/minting_system_overview.md
+++ b/docs/intuitionlabs/class_overviews/minting_system_overview.md
@@ -1,0 +1,45 @@
+# Ballet Bots Minting System Overview
+
+The minting system rewards Ballet Bots learners with on-chain badges that track milestones across the program. Badges double as narrative artifacts—each token celebrates a choreography breakthrough, debugging achievement, or community contribution.
+
+## Badge architecture
+
+- **Blockchain:** Ethereum-compatible sidechain (e.g., Polygon) chosen for low fees and educator-friendly tooling.
+- **Token standard:** ERC-1155 contract supporting batch minting for class cohorts while keeping metadata unique per badge.
+- **Metadata hosting:** JSON descriptors stored via IPFS with fallback caching on the program server for reliable access in low-connectivity settings.
+- **Access roles:**
+  - *Program Director* can update metadata templates, revoke badges in rare cases, and manage cohort configuration.
+  - *Facilitators* mint badges through a dashboard authenticated by OAuth and wallet delegation.
+  - *Learners* receive custodial wallets managed through guardian email approval; families can later export badges to a personal wallet.
+
+## Badge types
+
+| Badge | Trigger | Metadata Highlights |
+| --- | --- | --- |
+| `Warmup Voyager` | Completes Module 1 collaborative warmup and sets personal learning goal. | Animated gradient background, goal statement text field. |
+| `Choreo Debugger` | Demonstrates three iterative improvements during Module 2 coding labs. | Step-by-step code screenshots, facilitator annotations. |
+| `Sensor Storyteller` | Designs responsive routine using at least one sensor input in Module 3. | Sensor data capture snippet, audio mood selection. |
+| `Collaborative Composer` | Leads feedback session and documents action items in Module 4. | Team roster, peer shout-outs. |
+| `Stagecraft Specialist` | Integrates lighting or costume prototype during Module 5 build week. | Media gallery attachments, lighting preset tags. |
+| `Community Showcase` | Performs at Module 6 showcase and completes reflection journal. | Performance clip link, audience feedback quotes. |
+
+## Minting workflow
+
+1. Facilitators track milestones through the lesson dashboard or offline worksheets.
+2. At the end of each module, facilitators upload evidence (photos, notes, code snippets) through the secure minting interface.
+3. The backend verifies cohort eligibility, bundles metadata, and signs a minting transaction using delegated keys.
+4. Learners receive email/SMS notifications with badge previews and optional sharing links.
+5. Families can claim custody by connecting a personal wallet; otherwise, tokens remain in custodial accounts managed by IntuitionLabs.
+
+## Privacy and safety considerations
+
+- No sensitive personal information is stored on-chain; reflections and media attachments are stored in a secure off-chain bucket with expiring URLs.
+- Guardian approval is required before any learner-generated media becomes publicly viewable.
+- Token metadata emphasizes learning milestones rather than competitive rankings to maintain supportive class culture.
+- Contracts and dashboards undergo annual security reviews, and facilitators receive safety training for digital asset management.
+
+## Integration with Gemini CLI
+
+- Use Gemini CLI to draft badge narratives from facilitator notes, ensuring consistent tone and inclusive language.
+- Automate metadata QA by running CLI scripts that validate JSON schema and flag missing evidence links.
+- Generate celebratory showcase scripts or newsletter blurbs using the `/ask` assistant with badge metadata as context.

--- a/docs/intuitionlabs/teaching_materials/lesson_plans.md
+++ b/docs/intuitionlabs/teaching_materials/lesson_plans.md
@@ -1,0 +1,76 @@
+# Ballet Bots Lesson Plans
+
+Each session is designed for 90 minutes but can be condensed to 60 minutes by trimming optional extensions. The plans assume access to a makerspace with open floor area and two facilitators.
+
+## Session 1 – Storyworld Launch
+
+- **Focus:** Introduce Ballet Bots narrative and establish group norms.
+- **Agenda:**
+  1. `0:00–0:10` Arrival soundtrack & freeform movement warmup.
+  2. `0:10–0:25` Program overview, safety briefing, and community agreements.
+  3. `0:25–0:40` Robotics storyworld slideshow with facilitator-led demo.
+  4. `0:40–1:05` Team challenge: improvise “robot greetings” in trios, capture on tablets.
+  5. `1:05–1:20` Reflection circle; students record one goal in notebooks.
+- **Prep checklist:** Charge robots, stage lighting cues, print goal tracker sheets.
+
+## Session 2 – Coding Motions Lab
+
+- **Focus:** Translate choreography into block-based code.
+- **Agenda:**
+  1. `0:00–0:15` Rhythm mirroring warmup with tempo changes.
+  2. `0:15–0:35` Facilitator demo of loop blocks and timing controls.
+  3. `0:35–1:00` Stations: debugging relay, code remix challenge, tempo tester.
+  4. `1:00–1:20` Gallery walk and peer feedback using “Glow/Grow” sticky notes.
+- **Prep checklist:** Load starter projects, set up floor markers, print debugging rubrics.
+
+## Session 3 – Sensor Storytelling
+
+- **Focus:** Use sensors to trigger expressive movement.
+- **Agenda:**
+  1. `0:00–0:10` Breath and balance warmup with sensor props.
+  2. `0:10–0:30` Mini-lesson on inputs/outputs; quick unplugged simulation.
+  3. `0:30–1:05` Teams design responsive routines, test with audio cues.
+  4. `1:05–1:20` Reflection journaling and evidence upload for minting queue.
+- **Prep checklist:** Calibrate sensors, prepare optional audio loops, set up low-light corner.
+
+## Session 4 – Collaborative Composition
+
+- **Focus:** Co-create multi-part routines with narrative clarity.
+- **Agenda:**
+  1. `0:00–0:10` Trust-building warmup (mirrored walking with eyes closed).
+  2. `0:10–0:30` Introduce storyboard template and project roles (director, coder, movement lead).
+  3. `0:30–1:05` Teams iterate on storyboards, film rough cut, exchange critiques.
+  4. `1:05–1:20` Capture action items in shared doc; update badge progress tracker.
+- **Prep checklist:** Print storyboard templates, prepare critique sentence stems, ensure camera devices charged.
+
+## Session 5 – Showcase Build Sprint
+
+- **Focus:** Add production polish and technical reliability.
+- **Agenda:**
+  1. `0:00–0:15` Energy check-in and stage layout review.
+  2. `0:15–0:35` Rapid prototyping: lighting cues, costume experiments, audio mixing.
+  3. `0:35–1:10` Full run-throughs with timing notes, refine transitions.
+  4. `1:10–1:20` Stage management assignments and final checklist.
+- **Prep checklist:** Reserve performance space, gather costume bins, stage manager clipboard.
+
+## Session 6 – Community Showcase
+
+- **Focus:** Celebrate progress and capture evidence for minting.
+- **Agenda:**
+  1. `0:00–0:15` Sound check and backstage mindfulness exercise.
+  2. `0:15–0:55` Performance with family/community audience.
+  3. `0:55–1:10` Audience feedback wall and photo booth.
+  4. `1:10–1:20` Badge reveal ceremony and gratitude circle.
+- **Prep checklist:** Send reminders to families, set up livestream/recording, prepare badge QR cards.
+
+## Differentiation strategies
+
+- Offer tactile coding cards for learners who benefit from physical manipulatives.
+- Provide advanced debugging challenges for experienced coders (nested loops, dual-robot synchronization).
+- Pair English language learners with bilingual peers and offer vocabulary cards with visuals.
+
+## Facilitator reflection prompts
+
+- Which activity generated the most joyful engagement today?
+- Where did learners struggle, and how can tomorrow’s warmup scaffold that skill?
+- What badge evidence still needs to be captured before the next session?

--- a/docs/intuitionlabs/teaching_materials/student_worksheets.md
+++ b/docs/intuitionlabs/teaching_materials/student_worksheets.md
@@ -1,0 +1,69 @@
+# Ballet Bots Student Worksheets
+
+These printable resources pair with each session’s goals. Facilitators can duplicate and adapt them to local needs.
+
+## Worksheet A – Goal Setting & Movement Vocabulary (Session 1)
+
+| Prompt | Student Response |
+| --- | --- |
+| What feeling do you want audiences to notice in your performance? | |
+| Draw or name three robot-inspired moves you already know. | |
+| One thing I’m excited to learn is… | |
+| One way I’ll support my team is… | |
+
+**Extension:** Invite students to color-code moves that use high, medium, or low levels of energy.
+
+## Worksheet B – Debugging Journal (Session 2)
+
+| Challenge | What happened? | Fix attempt | Result |
+| --- | --- | --- | --- |
+| Robot stopped mid-routine | | | |
+| Timing felt off | | | |
+| Sensors didn’t trigger | | | |
+| Wildcard issue | | | |
+
+**Reflection prompt:** “What is one debugging strategy you want to remember next time?”
+
+## Worksheet C – Sensor Story Planner (Session 3)
+
+1. **Emotion cue:** When the sensor detects _________, our robot should express ________.
+2. **Movement sequence:** Draw or list 4–6 moves the robot performs in response.
+3. **Sound design:** Circle the audio mood that fits best: *Calm* / *Curious* / *Excited* / *Mysterious* / *Triumphant*.
+4. **Testing log:**
+
+| Trial | Sensor reading | Change made |
+| --- | --- | --- |
+| 1 | | |
+| 2 | | |
+| 3 | | |
+
+## Worksheet D – Feedback & Collaboration Notes (Session 4)
+
+| Team we observed | Glow (what worked well) | Grow (next steps) |
+| --- | --- | --- |
+| | | |
+| | | |
+| | | |
+
+**Team retro questions:**
+- What new idea did we adopt from feedback today?
+- Which role felt the busiest? How can we redistribute tasks?
+
+## Worksheet E – Showcase Checklist (Session 5)
+
+| Item | Ready? (Y/N) | Notes |
+| --- | --- | --- |
+| Robot battery charged | | |
+| Costume/props packed | | |
+| Audio cues exported | | |
+| Lighting cues tested | | |
+| Badge evidence captured | | |
+
+## Worksheet F – Reflection & Badge Claim (Session 6)
+
+1. The moment I’m most proud of from today was…
+2. A teammate I want to thank is… because…
+3. When I watch the recording, I notice…
+4. I’m excited to use my badge to share…
+
+**Family follow-up:** Provide QR code for badge claim plus conversation starters for at-home reflection.


### PR DESCRIPTION
## Summary
- add an IntuitionLabs documentation section that describes the Ballet Bots program
- document curriculum goals, badge minting system, lesson plans, and printable worksheets
- link the new resources from the main docs index under the Examples section

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68d8003d24188330abc24be96b2eed74