### PR TITLE
Merge codex/deploy-to-firebase-hosting into codex/deploy-firebase-codex-project

### DIFF
--- a/docs/firebase-hosting.md
+++ b/docs/firebase-hosting.md
@@ -4,6 +4,21 @@ This guide documents "Option C" — deploying the ready-to-run `mwra-glossary-fi
 project (for example, a personal "codex" sandbox) that hosts multiple front-ends under a single umbrella identity. The package
 contains everything required to serve the static glossary UI and proxy `/ask` requests through a token-protected Cloud Function.
 
+## Quick command summary
+
+If you have already customized the frontend and generated static assets (for example with `npm run build`, `next build`, or
+`astro build`), the Firebase CLI workflow is:
+
+```bash
+npm run build   # or next build / astro build / etc
+firebase login
+firebase init hosting  # When prompted, set the public directory to your build output (dist, out, etc.).
+firebase deploy
+```
+
+The sections below walk through the same process in more detail for the MWRA glossary starter kit, including configuring
+Hosting targets and HTTPS Functions.
+
 > **At a glance**
 >
 > * Works with the Firebase Spark (free) plan — no paid resources are required for the default configuration.


### PR DESCRIPTION
## Summary
- merge the latest changes from `codex/deploy-to-firebase-hosting` into `codex/deploy-firebase-codex-project`
- incorporate the quick Firebase CLI command summary into the hosting guide

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d886050ae08330907284c5883ea8e4