### PR TITLE
docs: document cloud run demo containers

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -83,6 +83,56 @@ You can run the most recently committed version of Gemini CLI directly from the 
 npx https://github.com/google-gemini/gemini-cli
 ```
 
+### 5. Demo containers (Google Cloud Run)
+
+For quick demos—especially when you do not want to build the project locally—you
+can use the pre-built containers published to Google Artifact Registry under the
+`starry-argon-463819-a2` project. These images mirror the Netlify demo and are
+ready to run on Google Cloud Run or locally with Docker.
+
+1. Authenticate Docker with Artifact Registry (only needs to be done once per
+   workstation):
+
+   ```bash
+   gcloud auth configure-docker us-central1-docker.pkg.dev
+   ```
+
+2. Inspect the available demo images:
+
+   ```bash
+   PROJECT=starry-argon-463819-a2
+   gcloud artifacts docker images list \
+     us-central1-docker.pkg.dev/${PROJECT}/cloud-run-source-deploy
+   ```
+
+3. Deploy a container to Cloud Run (replace `<IMAGE_NAME>` with one of the
+   images returned above):
+
+   ```bash
+   PROJECT=starry-argon-463819-a2
+   REGION=us-central1
+   SERVICE=gemini-glossary-demo
+   IMAGE=us-central1-docker.pkg.dev/${PROJECT}/cloud-run-source-deploy/<IMAGE_NAME>
+
+   gcloud run deploy ${SERVICE} \
+     --image=${IMAGE} \
+     --project=${PROJECT} \
+     --region=${REGION} \
+     --platform=managed \
+     --allow-unauthenticated
+   ```
+
+4. (Optional) Run the same container locally:
+
+   ```bash
+   docker run --rm -p 8080:8080 ${IMAGE}
+   ```
+
+When deployed, Cloud Run exposes the static glossary UI on the service URL and
+serves the `/ask` function from the same container. Add your `OPENAI_API_KEY`
+and other environment variables directly in the Cloud Run service configuration
+to enable live responses.
+
 ## Deployment architecture
 
 The execution methods described above are made possible by the following architectural components and processes:

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Gemini CLI brings the capabilities of Gemini models to your terminal in an inter
 This documentation is organized into the following sections:
 
 - **Execution and Deployment**
-  - **[Running locally and in sandboxes](./deployment.md):** Information for running Gemini CLI.
+  - **[Running locally, in sandboxes, and via Cloud Run](./deployment.md):** Information for running Gemini CLI.
   - **[Firebase Hosting quick start](./firebase-hosting.md):** Deploy the MWRA glossary demo with a single Firebase project.
 - **[Architecture Overview](./architecture.md):** Understand the high-level design of Gemini CLI, including its components and how they interact.
 - **CLI Usage:** Documentation for `packages/cli`.


### PR DESCRIPTION
## Summary
- add Cloud Run demo container instructions to the deployment guide
- highlight the new Cloud Run guidance from the documentation index

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68d9f4d199308330b385d5a61f6c7bea