### PR TITLE
Add jargon futures watchlist documentation

### DIFF
--- a/docs/jargon-futures-watchlist.md
+++ b/docs/jargon-futures-watchlist.md
@@ -1,0 +1,129 @@
+# Jargon Futures Watchlist
+
+This document captures every term, metaphor, and product seed coined during the most recent ideation thread.  
+Items are listed in chronological order with quick notes on connections, potential use cases, and immediate signals ("clicks/pops") that suggest follow-up experiments.
+
+## Chronological ledger of coinages
+
+| Order | Term / Phrase | Notes & potential trajectories | Immediate signal |
+| --- | --- | --- | --- |
+| 1 | **Screen Agents Guild** | Satirical nod to SAG; frames the multi-agent era as organized labor. | Connects to later "agent as performer" concepts. |
+| 2 | **RAG INTRA / INTRA** | Evolution of Retrieval-Augmented Generation toward internal state sharing. | Strong enterprise runway; pairs with Golden RAG. |
+| 3 | **Agents / Central Intuitive Agency** | CIA parody for orchestration hubs. | Recurred as "Agentic Ops" and management metaphors. |
+| 4 | **Architexture** | Systems-of-systems framing for infra storytelling. | Links to MetaWeave / Meshmind / InfraVerse. |
+| 5 | **AVC / xoxoAVC** | Autonomous Value Chains; also influencer-AI satire. | Seed for future ops acronyms. |
+| 6 | **Simulate** | Broad verb for scenario generation. | Background thread; no direct pops yet. |
+| 7 | **System / Auto** | Baseline references that reappear in Autonom- cluster. | Sets stage for Autonomate/Autonomoat. |
+| 8 | **Augmental** | Core augment coinage; cousin to augmented. | Drives Augmint, Augmeant, Augmentalist. |
+| 9 | **RAILS** | Regulatory/safety branding keyword. | Feeds RAILSRD, RAILSWAY, rodeoRAILS. |
+| 10 | **Blockchain / Webwebweb / Dotcombubble / Ubiquity** | Retro-ironic branding fuel. | Later echoed in Web³, Writer's Blockchain. |
+| 11 | **BOSS (Blockchain Optimized Safety Systems)** | Enterprise-friendly acronym. | Compatible with AI Stake Sauce finance layer. |
+| 12 | **AutoMouse** | Micro-agent automation brand. | Light click; could front UI macro tools. |
+| 13 | **Ottonom / Autonom / Autonomie / Autonomic** | Core autonomy brand roots. | High runway; inspire Autonomate, Autonomoat. |
+| 14 | **Autoniconomy / Autonomonics** | Economic framing of autonomous systems. | Pair with GenOps / economic modeling. |
+| 15 | **Autonomoat** | Automation + moat defensibility pun. | Strong click as defensible platform pitch. |
+| 16 | **Autonomate** | Automation helper brand. | Good SaaS naming candidate. |
+| 17 | **Metronomous** | Orchestration via rhythm. | Connects to Maestro/Conductor riffs. |
+| 18 | **RAGRICHES / Rags²Riches** | Monetization pun for RAG services. | High meme potential; combine with Retriever AG. |
+| 19 | **RAILSRD / RAILSWAY** | Safety rails R&D + productization. | Aligns with regulatory trends. |
+| 20 | **Augmint** | Augment + mint (finance/creation). | Top-tier runway; pair with AI Stake Sauce. |
+| 21 | **Augmeant** | "Augment was the point" wordplay. | Good for storytelling. |
+| 22 | **Augmentalist** | Specialist identity for augmentation pros. | Connects to education stack (Bot Gym). |
+| 23 | **Wiz of Aug / Wiz of Og** | Persona branding for augmentation experts. | Playful marketing for courses. |
+| 24 | **INTRA** | Clean prefix for inter-agent retrieval. | Foundation for INTRAgen, INTRAconnect. |
+| 25 | **Aether** | Mythic vibe; crowded but flexible. | Works as umbrella if available. |
+| 26 | **AI AGENCY** | Phrase for agent economy consultancies. | Ready for SEO now. |
+| 27 | **Iterations** | Generic but supports Bot Gym loops. | Use as blog theme. |
+| 28 | **Mach / Deus Ex Machina (DXM)** | Mythic automation frame. | Pair with CyclOPS. |
+| 29 | **AI TOKE** | AI x cannabis/crypto pun. | Meme-ready; sits with Token Sesh. |
+| 30 | **TOKE SESH / TOKESESH.CLOUD** | Lifestyle AI lounge vibe. | Viral naming potential. |
+| 31 | **Token Sesh / Tokenomics** | Crypto social club / economics pun. | Tokenomics crowded; Token Sesh fresher. |
+| 32 | **On chain / Off the chain / Writer's Blockchain / Web³** | Culture-aware blockchain riffs. | Web³ ideal for satire site. |
+| 33 | **GenOps** | Generative operations discipline. | Top 3 deploy-ready for enterprise USD. |
+| 34 | **Generational Cache / GenerativeZ / GenerativeX / Generatively** | Cultural variants on generative AI. | Use for segmentation content. |
+| 35 | **Next Top ML Model / Top Model Agents / Agentic Model Haus / Model Managers / Model Management Studio** | Treating agents like supermodels. | Connect with Screen Agents Guild + PersonaBiz. |
+| 36 | **Agentic Ops** | Agent operations discipline. | Aligns with GenOps for B2B offers. |
+| 37 | **LOOP / Feedback Loop / Ouroboros** | Recursion motif. | Root for LoopPool and CyclOPS. |
+| 38 | **HITL derivatives** | Human-in-the-loop renamings. | Feed Humaninthepool / Datainthepool. |
+| 39 | **Bootstrapped / BOTstrapped** | Startup/meme pun. | Good for newsletters. |
+| 40 | **Bot School / Machine Training / Training Club / AI Safety Social School / BASIC Academy** | Education stack coinages. | Bot School + Bot Gym synergy. |
+| 41 | **Prompt Party** | Community event concept. | Works as marketing funnel. |
+| 42 | **SiteSees / see.site** | AR/VR tourism naming. | Pair with PersonaCloud. |
+| 43 | **Codeographers / Monographs** | Artistic coder identity. | Good for blog branding. |
+| 44 | **Hologram / Sonique / Syrup** | Sensory brand seeds. | Sonique = audio AI; Syrup = sticky monetization. |
+| 45 | **SteveJoblessEconomy** | Satire brand. | Viral newsletter or merch. |
+| 46 | **Inversr Mr Rogers** | Ironic safety persona. | Meme potential. |
+| 47 | **Neuvermietung** | Accidental German for "new rental." | Could name agent leasing service. |
+| 48 | **Animatic / Tonomic / AUTONIC / Ottomath** | Additional autonomy variations. | AUTONIC stands out as component brand. |
+| 49 | **Maestro / Conductor / Steam Conductors** | Orchestration metaphors. | Combine with theatre system assets. |
+| 50 | **Off the RAILS / DamselRAILS / Train Track / Railroad Agents** | Regulation storytelling. | Align with AI safety narratives. |
+| 51 | **Token Tickets** | Token-gated access passes. | Pair with Token Sesh events. |
+| 52 | **DynTax / Syntaxi** | Dynamic tax & syntax pun. | Syntaxi suits LLM grammar tooling. |
+| 53 | **RodeoRAILS** | Chaotic safety training. | Fun event concept. |
+| 54 | **BOT GYM** | Core MVP metaphor; bots get workouts. | High click; deploy now. |
+| 55 | **Java Shop** | Coffee run for bots (prompt caffeine). | Pair with Bot Gym as daily boosts. |
+| 56 | **LoopPool / Looppool / Humaninthepool / Datainthepool** | Recursion training environment. | LoopPool rated top deploy. |
+| 57 | **BRAG** | Benchmark + Retrieve + Augment + Generate. | Could be productized framework. |
+| 58 | **CyclOPS** | Recursive nonlinear ops. | Mythic Ops framework; align with GenOps. |
+| 59 | **Neu Vous / NeuroVos / NeuraVU** | Neural personal brand set. | Corporate runway; use for neurotech experiments. |
+| 60 | **Neuzugang** | "New arrival" appropriation. | Use for onboarding flows. |
+| 61 | **Autonomagatchi** | Tamagotchi for agents. | Viral side project. |
+| 62 | **RAGrats** | Cartoonish RAG training brand. | Combine with Golden RAG marketing. |
+| 63 | **Retriever AG / Golden RAG / Golden Retriever AI** | RAG-as-dog metaphors. | Top deploy; fetch-as-a-service narrative. |
+| 64 | **Fitch AI / Bop Bot** | Playful assistant names. | Fit for Java Shop freebies. |
+| 65 | **Syns** | Synthesis shortform. | Works as note-taking brand. |
+| 66 | **Arboretum** | Knowledge-tree explorer. | Pair with Cache Up for visualization. |
+| 67 | **Systemic mnemonix Menü** | Memory architecture concept. | Use for NervösOS curriculum. |
+| 68 | **RUbiqx / Rubiquitous** | Modular puzzle brand. | Could power gamified training. |
+| 69 | **RAG-U Secret Sauce** | Secure key/info vault for RAG. | Align with AI Stake Sauce finance layer. |
+| 70 | **Sur** | Minimalist brand seed. | Could label umbrella OS modules. |
+| 71 | **DevCoOps / RagCoOps / Cooperations Manager** | Cooperative agent ops. | Perfect for Screen Agents Guild universe. |
+| 72 | **Persona / PersonaBiz / Show Biz** | Persona economy branding. | Bridge to Top Model Agents. |
+| 73 | **XYZ Factor** | Talent-show framing. | Pair with Model Haus competitions. |
+| 74 | **:she has :it:** | Minimal meme brand. | Use for merch or social drops. |
+| 75 | **NervösOS** | Umbrella operating metaphor. | Ideal backbone for deployment hub. |
+| 76 | **FineArtsAgency / ART OFFICIAL INTELLIGENCE / Artist Tree** | Art-tech branding. | Art Official Intelligence is SEO-ready. |
+| 77 | **DNA/RNA / Spiral Staircase** | Biological recursion metaphors. | Use for CyclOPS narrative. |
+| 78 | **Cache Up** | Glossary conflict resolver (existing MVP). | Immediate USD SEO play. |
+| 79 | **Girl Scout Cookies / Third Party Cookies / Fourth Wall Santa** | Cookie economy satire. | Seasonal marketing hooks. |
+| 80 | **AI for Trick or Treaters** | Holiday micro-campaign. | Potential limited drop. |
+| 81 | **Loop Pool** | Reinforcement of LoopPool brand. | Deploy now (USD ready). |
+| 82 | **AI Stake Sauce** | Staking + culinary pun. | Finance-layer branding; future upsell. |
+| 83 | **Glisse MVP / Theatre System / Offline AI Builder / MWRA Glossary** | Existing tooling assets. | Provide building blocks for above metaphors. |
+| 84 | **Golden RAG** | Reinforced brand while coding. | Already in build. |
+| 85 | **SEO Bumps in the Bot Bathroom** | Strategy metaphor for disposable SEO tests. | Guides current deployment tactics. |
+
+## Connections that “clicked”
+
+- **Agent-as-performer universe:** Screen Agents Guild, Top Model Agents, Agentic Model Haus, PersonaBiz, XYZ Factor, Cooperations Manager all orbit the same satire-friendly but productizable space.
+- **RAG dog park:** RAGRICHES, RAGrats, Retriever AG, Golden RAG, RAG-U Secret Sauce cluster into a coherent service/product ladder from meme marketing to secure retrieval infrastructure.
+- **Augmental finance:** Augmental, Augmint, Augmeant, AI Stake Sauce, BOSS create a finance-friendly narrative about staking, minting, and augmenting value.
+- **Loop training stack:** LoopPool, Bot Gym, Java Shop, BRAG, CyclOPS, Cache Up feed into a “train your agent” vertical that has both SaaS viability and SEO angles.
+- **Neuro-personal branding:** Neu Vous, NeuroVos, NeuraVU, NervösOS, Autonomagatchi suggest a consumer-facing neurotech/playful brand family.
+
+## Top 3 “deploy today” revenue plays
+
+1. **Bot Gym Lite**  
+   *Offer*: $9 prompt workout packs with optional subscription for new routines.  
+   *Why now*: Fitness metaphor converts instantly; minimal build (landing page + Stripe + PDF).  
+   *Stacking*: Upsell Java Shop daily boosts, cross-promote Bot School curriculum.
+
+2. **LoopPool**  
+   *Offer*: $9/month access to curated feedback loops and chain templates.  
+   *Why now*: Recursion story differentiates from generic prompt libraries; easy to ship with existing loop templates.  
+   *Stacking*: Bundle with Bot Gym for “full wellness,” feed metrics into NervösOS dashboard.
+
+3. **Retriever AG (Golden RAG)**  
+   *Offer*: Free trial + $29/month retrieval-as-a-service with playful “dog walk” reporting.  
+   *Why now*: RAG demand is surging; branding is memorable; existing scripts can scaffold daily fetch jobs.  
+   *Stacking*: Combine with RAG-U Secret Sauce (secure vault) and Rags²Riches marketing funnel.
+
+**Honorable finance crossover:** *AI Stake Sauce*—use as umbrella for staking/ETH later; for USD today it can host affiliate content about AI investing while hinting at future product drops.
+
+## Immediate next actions
+
+1. **Launch Bot Gym, LoopPool, Retriever AG landing pages** using the copy decks prepared in the companion deployment notes.  
+2. **Instrument each raindrop** with shared analytics + CRM tagging via NervösOS so you can watch which seeds sprout revenue first.  
+3. **Spin up supporting SEO posts** (from the prepared topic pack) to start “bot bathroom” drip traffic while Stripe buttons begin collecting USD.
+
+With these steps the dandelion engine starts generating real signal—and cash—while leaving room to layer on AI Stake Sauce or other experiments once the first USD flows in.


### PR DESCRIPTION
## Summary
- add a jargon futures watchlist document that captures every coined term from the ideation thread
- document connections between related concepts and highlight the top three revenue-ready launch ideas
- outline immediate next actions for deploying the highest-potential concepts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68da0bb8c4b0833082b19186422a0cb7