### PR TITLE
Add Stageport server demo endpoints

### DIFF
--- a/stageport-server/README.md
+++ b/stageport-server/README.md
@@ -1,0 +1,29 @@
+# Stageport Server (RAG Vault + License Flow) — Demo
+
+## What this repo is
+Minimal serverless endpoints for:
+- `/api/vault-query` — server-side RAG query for a faculty vault (vector search + LLM).
+- `/api/license-create-session` — Stripe Checkout session creation (license purchase).
+- `/api/webhooks-stripe` — Stripe webhook to create a license record and call contract flow.
+
+Designed for Vercel serverless or Cloud Run.
+
+## Env Variables (required)
+- PINECONE_API_KEY
+- PINECONE_ENV
+- PINECONE_INDEX_NAME
+- OPENAI_API_KEY  (or set GEMINI_API_KEY + use utils/llm.js)
+- STRIPE_SECRET_KEY
+- STRIPE_WEBHOOK_SECRET
+- PUBLIC_URL  (e.g., https://decryptthegirl.vercel.app)
+- FIRESTORE_CREDENTIALS_JSON (optional) or FIRESTORE_PROJECT for Firestore usage
+
+## Run locally
+1. `npm install`
+2. `npx vercel dev` (preferred)
+3. Set environment vars locally: `vercel env add ...` or a local `.env` for `vercel dev`.
+
+## Notes
+- Replace the LLM call with your prefered provider (Gemini sample included in utils/llm.js).
+- Replace Pinecone with your vector DB if desired.
+- This repo intentionally keeps business logic minimal and demonstrative; do not run in production without security hardening and secrets management.

--- a/stageport-server/api/license-create-session.js
+++ b/stageport-server/api/license-create-session.js
@@ -1,0 +1,44 @@
+import Stripe from 'stripe';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: '2022-11-15' });
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).send('Method Not Allowed');
+  try {
+    const {
+      facultyId,
+      licenseType = 'institutional',
+      institution = 'Unknown',
+      auditHash,
+    } = req.body || {};
+    if (!facultyId || !auditHash) {
+      return res.status(400).json({ error: 'facultyId and auditHash required' });
+    }
+
+    const priceMap = { institutional: 500000, internal: 99900 }; // cents
+    const priceCents = priceMap[licenseType] || priceMap.institutional;
+
+    const session = await stripe.checkout.sessions.create({
+      payment_method_types: ['card'],
+      mode: 'payment',
+      line_items: [
+        {
+          price_data: {
+            currency: 'usd',
+            product_data: { name: `Stageport License — ${facultyId}` },
+            unit_amount: priceCents,
+          },
+          quantity: 1,
+        },
+      ],
+      success_url: `${process.env.PUBLIC_URL}/license-success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${process.env.PUBLIC_URL}/license-cancel`,
+      metadata: { facultyId, licenseType, institution, auditHash },
+    });
+
+    res.json({ sessionId: session.id });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: err.message });
+  }
+}

--- a/stageport-server/api/license-create-session.js
+++ b/stageport-server/api/license-create-session.js
@@ -1,6 +1,6 @@
 import Stripe from 'stripe';
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: '2022-11-15' });
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' });
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') return res.status(405).send('Method Not Allowed');

--- a/stageport-server/api/vault-query.js
+++ b/stageport-server/api/vault-query.js
@@ -1,0 +1,86 @@
+import crypto from 'node:crypto';
+import { PineconeClient } from '@pinecone-database/pinecone';
+import { callLLM, embedText } from '../utils/llm.js';
+
+const pinecone = new PineconeClient();
+let pineconeReady;
+
+async function ensurePineconeReady() {
+  if (!pineconeReady) {
+    if (!process.env.PINECONE_API_KEY || !process.env.PINECONE_ENV) {
+      throw new Error('Pinecone env vars are required');
+    }
+    pineconeReady = pinecone.init({
+      apiKey: process.env.PINECONE_API_KEY,
+      environment: process.env.PINECONE_ENV,
+    });
+  }
+  await pineconeReady;
+  return pinecone.Index(process.env.PINECONE_INDEX_NAME);
+}
+
+function buildAuditHash(slices) {
+  const hash = crypto.createHash('sha256');
+  slices.forEach((slice) =>
+    hash.update(`${slice.id}|${slice.excerpt || ''}|${slice.score || ''}`),
+  );
+  return hash.digest('hex');
+}
+
+export default async function handler(req, res) {
+  try {
+    if (req.method !== 'POST') {
+      return res.status(405).send('Method Not Allowed');
+    }
+    const { facultyId, query, topK = 5 } = req.body || {};
+    if (!facultyId || !query) {
+      return res.status(400).json({ error: 'facultyId and query required' });
+    }
+
+    const vector = await embedText(query);
+
+    const index = await ensurePineconeReady();
+    const qres = await index.query({
+      vector,
+      topK,
+      includeMetadata: true,
+      filter: { facultyId },
+    });
+
+    const matches = qres.matches || [];
+    const sources = matches.map((m) => ({
+      id: m.id,
+      score: m.score,
+      title: m.metadata?.title || m.id,
+      excerpt: (m.metadata?.text || '').slice(0, 800),
+      url: m.metadata?.url || null,
+      author: m.metadata?.author || facultyId,
+      createdAt: m.metadata?.createdAt || null,
+    }));
+
+    const systemInstruction = `You are a conservatory-grade pedagogy summarizer. Given a query and source excerpts, produce JSON with keys:\n    - summary (max 120 words)\n    - blurb (2 sentences, program-note friendly)\n    - citations: array [{sourceId, excerptUsed, reason}]\n    If answer cannot be supported by sources, return {"insufficient": true, "sources": [...]}.
+    `;
+    const context = sources
+      .map(
+        (s, i) =>
+          `[[SRC ${i + 1} | id:${s.id} | score:${s.score}]]\n${s.excerpt}\n---`,
+      )
+      .join('\n');
+    const userPrompt = `Query: "${query}"\n\nContext:\n${context}\n\nReturn JSON only.`;
+
+    const llmText = await callLLM(systemInstruction, userPrompt);
+    const auditHash = buildAuditHash(sources);
+
+    return res.json({
+      facultyId,
+      query,
+      sources,
+      llmText,
+      provenanceAuditHash: auditHash,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: err.message });
+  }
+}

--- a/stageport-server/api/vault-query.js
+++ b/stageport-server/api/vault-query.js
@@ -81,6 +81,6 @@ export default async function handler(req, res) {
     });
   } catch (err) {
     console.error(err);
-    return res.status(500).json({ error: err.message });
+    return res.status(500).json({ error: 'An internal server error occurred.' });
   }
 }

--- a/stageport-server/api/webhooks-stripe.js
+++ b/stageport-server/api/webhooks-stripe.js
@@ -1,0 +1,52 @@
+import Stripe from 'stripe';
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: '2022-11-15' });
+
+async function sendContractForSignature(licenseRecord) {
+  console.log('Stub sendContractForSignature payload:', licenseRecord);
+}
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+export default async function handler(req, res) {
+  const sig = req.headers['stripe-signature'];
+  let event;
+  try {
+    const rawBody = Buffer.isBuffer(req.body)
+      ? req.body
+      : Buffer.from(req.body || '');
+    event = stripe.webhooks.constructEvent(
+      rawBody,
+      sig,
+      process.env.STRIPE_WEBHOOK_SECRET,
+    );
+  } catch (err) {
+    console.error('Webhook signature failure', err);
+    return res.status(400).send(`Webhook Error: ${err.message}`);
+  }
+
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object;
+    const meta = session.metadata || {};
+    const licenseRecord = {
+      facultyId: meta.facultyId,
+      licenseType: meta.licenseType,
+      institution: meta.institution,
+      auditHash: meta.auditHash,
+      amount: session.amount_total,
+      currency: session.currency,
+      signed: false,
+      createdAt: new Date().toISOString(),
+      checkoutSessionId: session.id,
+    };
+
+    console.log('License record to save:', licenseRecord);
+    await sendContractForSignature(licenseRecord);
+  }
+
+  return res.json({ received: true });
+}

--- a/stageport-server/api/webhooks-stripe.js
+++ b/stageport-server/api/webhooks-stripe.js
@@ -1,6 +1,6 @@
 import Stripe from 'stripe';
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: '2022-11-15' });
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, { apiVersion: '2024-06-20' });
 
 async function sendContractForSignature(licenseRecord) {
   console.log('Stub sendContractForSignature payload:', licenseRecord);

--- a/stageport-server/firestore-sample.json
+++ b/stageport-server/firestore-sample.json
@@ -1,0 +1,23 @@
+{
+  "faculties": {
+    "avc-founder": {
+      "id": "avc-founder",
+      "name": "Allison Van Cura",
+      "email": "acfwrites@gmail.com",
+      "vaultNamespace": "avc-founder"
+    }
+  },
+  "licenses": {
+    "license:2025-0001": {
+      "facultyId": "avc-founder",
+      "institution": "ModernArts Conservatory",
+      "auditHash": "0xabc123...",
+      "amount": 500000,
+      "currency": "usd",
+      "signed": false,
+      "checkoutSessionId": "cs_test_123",
+      "docusignEnvelopeId": null,
+      "createdAt": "2025-11-17T..."
+    }
+  }
+}

--- a/stageport-server/package.json
+++ b/stageport-server/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "stageport-server",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "vercel dev --listen 3000",
+    "lint": "echo 'no lint configured'"
+  },
+  "dependencies": {
+    "stripe": "^11.14.0",
+    "node-fetch": "^3.4.0",
+    "@pinecone-database/pinecone": "^0.0.24",
+    "form-data": "^4.0.0"
+  },
+  "engines": {
+    "node": "18.x"
+  }
+}

--- a/stageport-server/package.json
+++ b/stageport-server/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "stripe": "^16.1.0",
     "node-fetch": "^3.4.0",
-    "@pinecone-database/pinecone": "^0.0.24",
+    "@pinecone-database/pinecone": "^2.2.2",
     "form-data": "^4.0.0"
   },
   "engines": {

--- a/stageport-server/package.json
+++ b/stageport-server/package.json
@@ -7,7 +7,7 @@
     "lint": "echo 'no lint configured'"
   },
   "dependencies": {
-    "stripe": "^11.14.0",
+    "stripe": "^16.1.0",
     "node-fetch": "^3.4.0",
     "@pinecone-database/pinecone": "^0.0.24",
     "form-data": "^4.0.0"

--- a/stageport-server/utils/llm.js
+++ b/stageport-server/utils/llm.js
@@ -1,0 +1,69 @@
+import fetch from 'node-fetch';
+
+/**
+ * Minimal callLLM wrapper: choose OPENAI or GEMINI depending on env.
+ * Returns text result.
+ */
+export async function callLLM(systemInstruction, userPrompt) {
+  if (process.env.GEMINI_API_KEY) {
+    const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-09-2025:generateContent?key=${process.env.GEMINI_API_KEY}`;
+    const payload = {
+      contents: [{ parts: [{ text: userPrompt }] }],
+      systemInstruction: { parts: [{ text: systemInstruction }] },
+    };
+    const r = await fetch(apiUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!r.ok) {
+      const t = await r.text();
+      throw new Error('Gemini error: ' + t);
+    }
+    const json = await r.json();
+    return json.candidates?.[0]?.content?.parts?.[0]?.text || '';
+  }
+
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      temperature: 0.1,
+      messages: [
+        { role: 'system', content: systemInstruction },
+        { role: 'user', content: userPrompt },
+      ],
+      max_tokens: 800,
+    }),
+  });
+  if (!res.ok) {
+    const t = await res.text();
+    throw new Error('OpenAI error: ' + t);
+  }
+  const j = await res.json();
+  return j.choices?.[0]?.message?.content || '';
+}
+
+/**
+ * Embeddings helper that uses OpenAI text-embedding-3-large.
+ */
+export async function embedText(text) {
+  const r = await fetch('https://api.openai.com/v1/embeddings', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ model: 'text-embedding-3-large', input: text }),
+  });
+  if (!r.ok) {
+    const t = await r.text();
+    throw new Error('Embeddings error: ' + t);
+  }
+  const j = await r.json();
+  return j.data?.[0]?.embedding;
+}


### PR DESCRIPTION
## Summary
- add a stageport-server demo folder with serverless endpoints for the vault RAG query and Stripe licensing flows
- provide shared LLM utilities and sample Firestore data
- document environment requirements and local development steps

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691be0ad6e408330bd1c6e8c2fc27601)