### PR TITLE
Add Founder StudiOS onboarding corridor and dashboard ledger visibility

### DIFF
--- a/stageport-portal-template/app/app/founder/page.tsx
+++ b/stageport-portal-template/app/app/founder/page.tsx
@@ -1,5 +1,10 @@
 'use client';
 
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { FounderStates, type FounderState, transition } from '../../../lib/founderMachine';
+import type { LedgerEntry } from '../../../lib/ledgerStore';
+
 type OpState = 'intake' | 'scope' | 'governance' | 'seal' | 'release';
 
 const founderSteps: OpState[] = ['intake', 'scope', 'governance', 'seal', 'release'];
@@ -27,13 +32,84 @@ export default function FounderDashboardPage() {
   const journeyState: OpState = 'governance';
   const totalSteps = founderSteps.length;
   const completedSteps = Math.min(getStepIndex(journeyState), totalSteps);
-  const journeyLedgerCount = 0;
+
+  const [founderState, setFounderState] = useState<FounderState>(FounderStates.IDLE);
+  const [ledgerRows, setLedgerRows] = useState<LedgerEntry[]>([]);
+  const [ledgerErr, setLedgerErr] = useState<string>('');
+
+  function doTransition(action: string) {
+    const next = transition(founderState, action);
+    setFounderState(next);
+  }
+
+  async function loadLedger() {
+    setLedgerErr('');
+    try {
+      const res = await fetch('/api/ledger');
+      if (!res.ok) throw new Error(`Ledger fetch failed (${res.status})`);
+      const data = (await res.json()) as unknown;
+      const rows = Array.isArray(data) ? data : [];
+      setLedgerRows(rows.slice(0, 10));
+    } catch (ex: unknown) {
+      const message = ex instanceof Error ? ex.message : 'Failed to load ledger';
+      setLedgerErr(message);
+    }
+  }
+
+  useEffect(() => {
+    void loadLedger();
+  }, []);
 
   return (
     <main style={{ maxWidth: 900, margin: '40px auto', padding: 24 }}>
       <h2>Founder Dashboard</h2>
+      <div style={{ border: '1px solid #ddd', borderRadius: 10, padding: 12, marginBottom: 12 }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+          <div>
+            <div style={{ fontSize: 12, opacity: 0.8 }}>Founder State</div>
+            <div style={{ fontSize: 18, fontWeight: 800 }}>{founderState}</div>
+          </div>
+
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            <button onClick={() => doTransition('START_BUILD')}>START_BUILD</button>
+            <button onClick={() => doTransition('THROTTLE')}>THROTTLE</button>
+            <button onClick={() => doTransition('RESET')}>RESET</button>
+            <button onClick={loadLedger}>Refresh Ledger</button>
+          </div>
+        </div>
+
+        <hr style={{ margin: '12px 0' }} />
+
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+          <div style={{ fontWeight: 800 }}>Recent Ledger Entries</div>
+          <Link href="/founder-studios" style={{ fontSize: 13 }}>
+            Open StudiOS Onboarding →
+          </Link>
+        </div>
+
+        {ledgerErr ? <div style={{ color: 'crimson' }}>{ledgerErr}</div> : null}
+
+        <div style={{ marginTop: 8, fontFamily: 'monospace', fontSize: 12 }}>
+          {ledgerRows.length === 0 ? (
+            <div style={{ opacity: 0.7 }}>No entries yet.</div>
+          ) : (
+            ledgerRows.map((r, idx) => (
+              <div key={`${r.hash}-${idx}`} style={{ padding: '6px 0', borderBottom: '1px dashed #eee' }}>
+                <div>
+                  <b>{r.eventType || 'EVENT'}</b>{' '}
+                  <span style={{ opacity: 0.7 }}>
+                    {r.documentId ? `· ${r.documentId}` : ''}
+                    {r.createdAt ? ` · ${r.createdAt}` : ''}
+                  </span>
+                </div>
+                {r.hash ? <div>hash: {String(r.hash).slice(0, 16)}…</div> : null}
+              </div>
+            ))
+          )}
+        </div>
+      </div>
       <p style={{ fontSize: 12, color: '#64748b' }}>
-        {completedSteps} of {totalSteps} steps notarized · {journeyLedgerCount} ledger events
+        {completedSteps} of {totalSteps} steps notarized · {ledgerRows.length} ledger events
       </p>
       <div style={{ width: '100%', height: 8, background: '#e2e8f0', borderRadius: 99 }}>
         <div
@@ -55,6 +131,7 @@ export default function FounderDashboardPage() {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ documentId: 'founder:demo', hash, eventType: 'FOUNDER_TRANSITION' }),
           });
+          await loadLedger();
         }}
       >
         Start Build

--- a/stageport-portal-template/app/app/page.tsx
+++ b/stageport-portal-template/app/app/page.tsx
@@ -7,6 +7,7 @@ import PortalFooter from '../../components/PortalFooter';
 const routes = [
   { href: '/kinetic-ledger', label: 'Kinetic Ledger' },
   { href: '/founderos/sandbox', label: 'FounderOS' },
+  { href: '/founder-studios', label: 'Founder StudiOS' },
   { href: '/app/founder', label: 'Founder Dashboard' },
   { href: '/app/sessions', label: 'Sessions' },
   { href: '/app/ledger', label: 'Ledger' },

--- a/stageport-portal-template/app/founder-studios/page.tsx
+++ b/stageport-portal-template/app/founder-studios/page.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { useMemo, useState, type ChangeEvent } from 'react';
+import PortalFooter from '../../components/PortalFooter';
+import PortalNavigation from '../../components/PortalNavigation';
+
+type StepKey = 'CRISIS' | 'LAB' | 'RECEIPTS' | 'STAGECRED' | 'CAPITAL';
+
+const STEPS: { key: StepKey; title: string; subtitle: string }[] = [
+  { key: 'CRISIS', title: 'Crisis', subtitle: 'Intake + constraints (what’s breaking, what must not break)' },
+  { key: 'LAB', title: 'Lab Activation', subtitle: 'Create the studio container (rules, corridors, boundaries)' },
+  { key: 'RECEIPTS', title: 'Receipts', subtitle: 'Ledger the decisions (proof-of-work, not vibes)' },
+  { key: 'STAGECRED', title: 'StageCred', subtitle: 'Credential ladder (unlock next tier via receipts)' },
+  { key: 'CAPITAL', title: 'Capital', subtitle: 'Export proof + metrics into investor-ready artifacts' },
+];
+
+function bufToHex(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let hex = '';
+  for (let i = 0; i < bytes.length; i += 1) {
+    hex += bytes[i].toString(16).padStart(2, '0');
+  }
+  return hex;
+}
+
+async function sha256File(file: File): Promise<string> {
+  const buf = await file.arrayBuffer();
+  const digest = await crypto.subtle.digest('SHA-256', buf);
+  return bufToHex(digest);
+}
+
+export default function FounderStudioOSPage() {
+  const [step, setStep] = useState<StepKey>('CRISIS');
+
+  const [fileName, setFileName] = useState<string>('');
+  const [hash, setHash] = useState<string>('');
+  const [hashing, setHashing] = useState(false);
+
+  const [notarizing, setNotarizing] = useState(false);
+  const [notarized, setNotarized] = useState(false);
+  const [err, setErr] = useState<string>('');
+
+  const documentId = useMemo(() => 'stageport-founder-reality-kit-v1', []);
+
+  async function onUpload(e: ChangeEvent<HTMLInputElement>) {
+    setErr('');
+    setNotarized(false);
+    setHash('');
+    const f = e.target.files?.[0];
+    if (!f) return;
+    setFileName(f.name);
+
+    try {
+      setHashing(true);
+      const h = await sha256File(f);
+      setHash(h);
+    } catch (ex: unknown) {
+      const message = ex instanceof Error ? ex.message : 'Failed to hash file';
+      setErr(message);
+    } finally {
+      setHashing(false);
+    }
+  }
+
+  async function notarize() {
+    setErr('');
+    setNotarized(false);
+    if (!hash) {
+      setErr('No hash computed yet.');
+      return;
+    }
+
+    try {
+      setNotarizing(true);
+      const res = await fetch('/api/ledger/notarize', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          documentId,
+          hash,
+          eventType: 'ISSUED',
+        }),
+      });
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(`Notarize failed (${res.status}): ${text || 'Unknown error'}`);
+      }
+
+      setNotarized(true);
+    } catch (ex: unknown) {
+      const message = ex instanceof Error ? ex.message : 'Notarize failed';
+      setErr(message);
+    } finally {
+      setNotarizing(false);
+    }
+  }
+
+  return (
+    <div>
+      <PortalNavigation />
+      <main style={{ padding: 16, maxWidth: 920, margin: '0 auto' }}>
+        <h2>StagePort Startup StudiOS</h2>
+        <p>
+          StagePort Startup StudiOS is a conservatory operating system for early-stage founders. It teaches structural coherence under stress: barre → repetition → receipts → credential → capital. Not dance-themed—discipline-themed. Portable across tech, art, services, education, science. Most tools celebrate speed. StagePort measures it, constrains it, and records why.
+        </p>
+
+        <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', marginTop: 12 }}>
+          {STEPS.map((s) => (
+            <button
+              key={s.key}
+              onClick={() => setStep(s.key)}
+              style={{
+                padding: '8px 10px',
+                borderRadius: 8,
+                border: '1px solid #ccc',
+                background: step === s.key ? '#f2f2f2' : 'white',
+                cursor: 'pointer',
+              }}
+            >
+              <div style={{ fontWeight: 700 }}>{s.title}</div>
+              <div style={{ fontSize: 12, opacity: 0.8 }}>{s.subtitle}</div>
+            </button>
+          ))}
+        </div>
+
+        <hr style={{ margin: '16px 0' }} />
+
+        <h3>Phase 1: Notarize the Founder Reality Kit</h3>
+        <p>
+          This turns the PDF from “a file” into a governed asset with receipts: <b>PDF → Hash → Ledger</b>.
+        </p>
+
+        <div style={{ display: 'flex', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}>
+          <input type="file" accept="application/pdf" onChange={onUpload} />
+          <button onClick={notarize} disabled={hashing || notarizing || !hash}>
+            {notarizing ? 'Notarizing…' : 'Notarize to Ledger'}
+          </button>
+        </div>
+
+        <div style={{ marginTop: 10, fontSize: 13 }}>
+          <div>
+            <b>DocumentId:</b> {documentId}
+          </div>
+          <div>
+            <b>File:</b> {fileName || '—'}
+          </div>
+          <div>
+            <b>Hash:</b> {hashing ? 'Hashing…' : hash || '—'}
+          </div>
+          <div>
+            <b>Status:</b> {notarized ? 'Ledger notarized ✅' : 'Not notarized yet'}
+          </div>
+          {err ? (
+            <div style={{ color: 'crimson', marginTop: 8 }}>
+              <b>Error:</b> {err}
+            </div>
+          ) : null}
+        </div>
+
+        <hr style={{ margin: '16px 0' }} />
+
+        <h3>Current Step: {STEPS.find((x) => x.key === step)?.title}</h3>
+        <p style={{ opacity: 0.9 }}>{STEPS.find((x) => x.key === step)?.subtitle}</p>
+
+        <div style={{ padding: 12, border: '1px solid #ddd', borderRadius: 10 }}>
+          {step === 'CRISIS' && <p>Write the constraint: what must not break. This is the founder’s alignment check before movement starts.</p>}
+          {step === 'LAB' && <p>Define corridors: who owns what, who can escalate, what gets logged. This is the barre.</p>}
+          {step === 'RECEIPTS' && <p>Ledger every meaningful decision. Receipts are your non-emotional memory under pressure.</p>}
+          {step === 'STAGECRED' && <p>StageCred is earned by verified receipts. No receipts, no cred. No cred, no leverage.</p>}
+          {step === 'CAPITAL' && <p>Capital is downstream of proof. Export the ledger trail into investor/grant outputs.</p>}
+        </div>
+      </main>
+      <PortalFooter />
+    </div>
+  );
+}

--- a/stageport-portal-template/lib/founderMachine.ts
+++ b/stageport-portal-template/lib/founderMachine.ts
@@ -1,0 +1,21 @@
+export const FounderStates = {
+  IDLE: 'IDLE',
+  BUILDING: 'BUILDING',
+  THROTTLED: 'THROTTLED',
+} as const;
+
+export type FounderState = (typeof FounderStates)[keyof typeof FounderStates];
+
+export function transition(state: FounderState, event: string): FounderState {
+  if (event === 'RESET') return FounderStates.IDLE;
+
+  if (state === FounderStates.IDLE && event === 'START_BUILD') {
+    return FounderStates.BUILDING;
+  }
+
+  if (state === FounderStates.BUILDING && event === 'THROTTLE') {
+    return FounderStates.THROTTLED;
+  }
+
+  return state;
+}

--- a/stageport-portal-template/replit.md
+++ b/stageport-portal-template/replit.md
@@ -12,3 +12,343 @@
 - `/app/contracts`
 - `/app/founder`
 - `/app/founder/onboarding`
+
+---
+
+## INSTITUTIONAL MEMORY — SESSION CANON (APPEND-ONLY)
+
+This section is forward-architecture canon. It is intentionally additive.
+Do not modify existing system behavior. Do not refactor. Do not delete.
+
+### SESSION RULES (DO NOT MODIFY EXISTING SYSTEM BEHAVIOR)
+
+#### Strict Engineering Rules
+- Additive changes only.
+- No refactors.
+- No deletions.
+- No new dependencies.
+- No architectural substitutions.
+- Preserve all existing endpoints and behaviors.
+
+#### Contact
+- Official contact: avancura@globalavcsystems.com
+- Never use test emails from attachments.
+
+#### Crypto Patterns
+- Kinetic Ledger = Client-side Web Crypto API only.  
+  No server storage of raw ledger content.
+- FounderOS Sandbox = Server hash + notarize only.  
+  Real ledger writes permitted here.
+
+#### Hash Validation Guard
+Use this guard for sha256 presence validation:
+
+typeof data?.sha256 === "string" && data.sha256.trim().length > 0
+
+#### FounderOS documentId Pattern
+Document ID format:
+
+founderos:{clampDocIdCompany(company)}
+
+Constraints:
+- Sanitized
+- Max 64 characters
+- Deterministic
+- No unsafe characters
+
+---
+
+## REVENUE LADDER (CANONICAL)
+
+This is not theoretical. The first ladder has already converted organically.
+
+### Tier 1 — $79
+**Founder Stability Primer**
+- SEO magnet
+- Entry wedge
+- Trust builder
+- Self-serve diagnostic
+
+### Tier 2 — $2,500
+**Governance Triage Sprint**
+- 90-minute intake
+- Structured diagnostic
+- Contribution exposure map
+- Notarized findings
+- Front door offer
+
+### Tier 3 — $7,500
+**Studio Install (30-day governance implementation)**
+- Governance substrate
+- Ledger scaffolding
+- Documentation structure
+- Capital readiness prep
+
+### Tier 4 — $15,000+
+**Certification + Capital Memo**
+- Full 3-gate certification
+- Executive memo for capital presentation
+- Registry listing
+
+### Tier 5 — $1,200/year
+**Registry Renewal**
+- Annual re-validation
+- Drift monitoring
+- Ongoing eligibility
+
+### Conversion Pattern (Proven)
+$79 → $2.5K → $7.5K  
+Organic conversion confirmed. Not speculative.
+
+---
+
+## FOUNDEROS GAAS (GOVERNANCE-AS-A-SERVICE) MODEL
+
+Three-layer architecture:
+
+### Layer 1 — Free Sandbox (BUILT)
+Route: `/founderos/sandbox`
+- No login required
+- Real ledger writes
+- Hash notarization
+- Public trust wedge
+
+### Layer 2 — Paid Triage Sprint ($2,500 — LIVE)
+- Structured diagnostic
+- Contribution exposure mapping
+- Governance gap analysis
+- Formal findings
+
+### Layer 3 — Full Install (FUTURE)
+- Server-side secure logging
+- Multi-user roles
+- Weighted contribution scoring
+- Corridor governance mapping
+- Capital readiness configuration
+- Institutional substrate
+
+---
+
+## AVC CERTIFICATION MODEL (3-GATE SYSTEM)
+
+No partial credit. All gates must pass.
+
+### Gate 1 — DeepScore
+Bayesian posterior mean:
+- μ ≥ 80
+- σ ≤ defined uncertainty cap
+
+### Gate 2 — Drift Stability
+- Max deviation Δ ≤ ±5 over rolling 30-day window
+- Torque τ below volatility ceiling
+
+### Gate 3 — Documentation Substrate Index (DSI)
+Composite ≥ 15/20 across four dimensions:
+- Traceability
+- Governance logging
+- Role clarity
+- Contribution mapping
+
+---
+
+## TIER ASSIGNMENT (WEAKEST-LINK RULE)
+
+Overall tier = lowest qualifying band across gates.
+
+### Tier I — Structured
+- μ 80–84
+- Δ ≤ 5
+- DSI ≥ 15
+
+### Tier II — Stable
+- μ 85–89
+- Δ ≤ 3
+- DSI ≥ 17
+
+### Tier III — Institutional
+- μ ≥ 90
+- Δ ≤ 2
+- DSI ≥ 19
+
+---
+
+## SPORKLIFT CERTIFIED FORK ARCHITECTURE
+
+Designed for controlled extensibility without dilution.
+
+### Level 0 — AVC Core (Non-Forkable)
+Protected components (cannot be modified):
+- Bayesian engine
+- Drift model
+- Minimum thresholds
+- Documentation gates
+- Hash signature format
+- Tier naming convention
+
+### Level 1 — Sporklift Fork (Controlled Adaptation)
+May modify:
+- Industry-specific metrics
+- Window length ≥ 30 days
+- Weight matrices
+- UX layer
+
+May NOT:
+- Lower μ thresholds
+- Remove drift or documentation gates
+- Alter tier naming without namespace change
+
+### Fork Requirements
+- Declare diff from core
+- Publish weight delta file
+- Pass regression test suite
+- Receive Fork ID
+
+### Registry Record Format
+```json
+{
+  "core_version": "",
+  "fork_namespace": "",
+  "score_posterior": "",
+  "drift_variance": "",
+  "dsi_score": "",
+  "tier": "",
+  "issued_at": "",
+  "hash": ""
+}
+
+Tier III Window Extensions
+	•	Core: 30 days
+	•	Institutional Capital Fork: 60 days
+	•	Public Markets Fork: 90 days
+
+Longer window = higher stability requirement.
+
+⸻
+
+STABILITY SCAN PRODUCT (FUTURE)
+
+Local-first founder scan — $750
+
+Runs entirely in browser. No data leaves machine.
+
+Outputs:
+	•	Institutional Score
+	•	Tier
+	•	Capital Risk
+	•	Drift Sensitivity
+	•	Downloadable Executive Memo (PDF)
+
+Behind the scenes:
+	•	Bayesian scoring engine
+	•	State machine gating
+	•	Drift modeling
+	•	Regime torque check
+
+Feature:
+	•	“Explain Mode” transparency toggle
+
+Upgrade path:
+	•	“Submit for Certification”
+	•	Upload hash + selected proofs to AVC Certification Registry
+
+⸻
+
+STUDIO TRANSACTION LAYER (FUTURE)
+
+Pirouette Ledgers — $19
+Credential / evaluation / score artifact
+
+Revenue Split
+	•	2% platform fee
+	•	Studio retains 98%
+	•	Via Stripe Connect
+
+Stripe Connect Flow
+	1.	Studio installs AVC Studio OS
+	2.	Studio connects Stripe account
+	3.	Student purchases ledger
+	4.	Automatic split (98% / 2%)
+
+Scale Modeling
+	•	1,000 studios → ~$171K/year
+	•	5,000 studios → ~$855K/year
+	•	10,000 studios → ~$1.7M/year
+
+Ledger must become:
+	•	Competition infrastructure
+	•	Advancement criteria
+	•	Certification eligibility
+	•	Instructor credentialing input
+	•	Scholarship signal
+
+Not optional art. Institutional substrate.
+
+⸻
+
+SEO STRATEGY
+
+Primary wedge: Kinetic Ledger
+
+Target keywords:
+	•	“founder contribution protection”
+	•	“governance as a service”
+	•	“startup governance framework”
+
+Focus:
+	•	Low competition
+	•	High-intent traffic
+	•	Qualified founder searches
+	•	SEO feeding high-ticket conversion
+
+⸻
+
+90-DAY FOCUS PLAN (OPERATIONAL)
+
+Primary Objective: Systematize ladder conversion.
+
+Core Targets
+	•	Convert $79 → $2.5K → $7.5K reliably
+	•	Close 5 installs in 3 months
+	•	10 installs in 6 months
+
+Execution Priorities
+	1.	Document first founder case study
+	2.	Build onboarding SOP
+	3.	Standardize 30-day governance install deliverables
+	4.	Create repeatable pitch script
+	5.	Refine intake structure
+	6.	Tighten capital memo template
+
+Deliverables
+	•	Install checklist
+	•	Governance substrate template
+	•	Drift baseline measurement protocol
+	•	Certification readiness pre-check
+	•	Capital memo boilerplate
+
+⸻
+
+STRATEGIC INTENT
+
+FounderOS is not a tool.
+It is institutional governance infrastructure.
+
+Certification is not a badge.
+It is capital signaling.
+
+Sporklift is not open source chaos.
+It is controlled extensibility with protected core.
+
+Studio Ledger is not art tech.
+It is transactional credential infrastructure.
+
+Revenue ladder is not theoretical.
+It is validated progression.
+
+All strategic architecture, revenue modeling, certification spec, fork structure, SEO positioning, and operational targets are now formally preserved inside replit.md scope.
+
+Nothing from the 4,362-line roadmap is conceptually lost.
+
+Next phase is execution density, not reinvention.
+
+⸻


### PR DESCRIPTION
### Motivation
- Preserve and surface the appended institutional memory and revenue ladder so the platform's commercial shape is visible and immutable in-repo.
- Provide a minimal, additive onboarding corridor that lets founders notarize a canonical “Founder Reality Kit” quickly using only WebCrypto and existing ledger endpoints.
- Surface recent ledger receipts and a small founder state machine in the dashboard to keep strategic context visible to engineers and users.

### Description
- Appended the exact INSTITUTIONAL MEMORY — SESSION CANON (APPEND-ONLY) block to `stageport-portal-template/replit.md` without refactors or deletions (append-only content preserved verbatim). 
- Added a new StudiOS onboarding page at `stageport-portal-template/app/founder-studios/page.tsx` that provides a 5-step UI, PDF upload, in-browser SHA-256 via WebCrypto, and notarization using the existing `POST /api/ledger/notarize` endpoint, with on-screen filename/hash/status/error display.
- Introduced a lightweight founder state machine at `stageport-portal-template/lib/founderMachine.ts` and wired it into the founder dashboard at `stageport-portal-template/app/app/founder/page.tsx`, which now shows `FounderState` plus `START_BUILD` / `THROTTLE` / `RESET` controls and fetches recent ledger entries from the existing `GET /api/ledger` endpoint.
- Added `/founder-studios` to the dashboard route list in `stageport-portal-template/app/app/page.tsx` for discoverability; no backend routes or new dependencies were added and no existing endpoints were changed.

### Testing
- Ran `npm run build` inside `stageport-portal-template` and the build completed successfully and listed `/founder-studios` among generated routes (build output confirms route presence). 
- Started the dev server (`npm run dev`) to smoke the app and attempted a Playwright screenshot to validate the page, but the Chromium process crashed with a SIGSEGV in this environment so no screenshot artifact was produced. 
- Verified the new pages compile as part of the Next.js build; ledger interactions use the platform's existing `POST /api/ledger/notarize` and `GET /api/ledger` routes and were exercised where possible during local validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a11ccb84f88330ae1b7d05233d6e61)