### PR TITLE
docs(adr): add ADR set for safety boundaries and Evidence Vault governance

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,54 @@
+# Architecture Decision Records (ADR)
+
+This folder stores architecture decisions for safety-critical product boundaries (privacy, consent, escalation, retention, cryptographic integrity).
+
+## Naming convention
+
+- `adr-001-<short-title>.md`
+- Zero-padded sequence numbers for stable sorting.
+
+## Recommended template (MADR)
+
+```md
+# ADR XXX: <Title>
+
+**Status**: Accepted / Proposed / Deprecated / Superseded
+**Deciders**: <names/roles>
+**Consulted**: <optional>
+**Informed**: <optional>
+**Date**: YYYY-MM-DD
+
+## Context and Problem Statement
+
+## Considered Options
+
+### Option 1: <name>
+- Pros:
+- Cons:
+
+### Option 2: <name>
+- Pros:
+- Cons:
+
+## Decision Outcome
+
+**Chosen option:** "<name>"
+
+## Positive Consequences
+
+## Negative Consequences
+
+## Risks & Mitigations
+
+## More Information
+```
+
+## Current ADR set
+
+- ADR 001: Session-bounded human escalation
+- ADR 004: Data minimization and purpose limitation
+- ADR 005: Immediate post-session deletion
+- ADR 006: Client-side encryption with user-controlled keys
+- ADR 007: Offline-first local-only Vault storage
+- ADR 008: Minimal local tamper-evident access logging
+- ADR 009: Cryptographic integrity verification

--- a/docs/adr/adr-001-use-session-bounded-signaling-only.md
+++ b/docs/adr/adr-001-use-session-bounded-signaling-only.md
@@ -1,0 +1,94 @@
+# ADR 001: Use Session-Bounded Human-Escalation Signaling Instead of Predictive or Always-On Monitoring
+
+**Status**: Accepted  
+**Deciders**: Lilly Simpson (CEO), Engineering Lead, AVC Governance Consultant  
+**Date**: 2026-02-20  
+**Consulted**: AVC Systems Studio (Allison Van Cura)  
+**Informed**: Future investors / diligence partners
+
+## Context
+
+We are building an everyday safety app for college women, with features including location sharing, risk awareness, discreet alerts, and community connections. Early user interviews and campus feedback highlight the need for reliable, low-friction safety signaling during high-risk walks (library → dorm, party → ride, etc.).
+
+Several architectural patterns are common in the personal safety category:
+
+- Predictive risk scoring (machine learning on crime data + user behavior)
+- Always-on background GPS/sensor monitoring with anomaly detection
+- Direct 911/emergency services integration
+- Continuous ambient tracking with automated escalation
+
+These approaches promise proactive protection but carry significant early-stage risks for a pre-launch startup.
+
+## Considered Options
+
+### Option 1: Predictive Safety Intelligence (ML-based risk scoring + proactive alerts)
+
+- Pros: High perceived value; aligns with “AI-powered” marketing language
+- Cons: Requires large, clean datasets (unavailable at MVP); high false-positive/negative risk; creates implied duty of care; substantial legal/regulatory exposure (privacy, discrimination, accuracy claims)
+
+### Option 2: Always-On Background Monitoring + Auto-Escalation
+
+- Pros: “Set it and forget it” user experience; potential for faster response
+- Cons: Severe battery drain; persistent location tracking raises privacy consent issues; shifts responsibility from user to system; high liability for missed detections or false alarms
+
+### Option 3: Direct Emergency Services Integration
+
+- Pros: Fastest path to real help in clear emergencies
+- Cons: Jurisdictional complexity; very high liability for false positives; inflexible for ambiguous situations (bad date, uncomfortable walk, etc.); requires significant compliance/certification effort
+
+### Option 4: Session-Bounded Human-Escalation Signaling (Chosen)
+
+- Description: User starts a session manually (e.g., “I’m walking home”); system emits time-scoped signals/check-ins; missed responses escalate only to pre-configured trusted human contacts; minimal event logging; no prediction, no automation, no continuous tracking.
+- Pros:
+  - Aligns authority with explicit user intent
+  - Keeps humans in the loop (context-aware interpretation)
+  - Minimal data collection → easier privacy story
+  - Low battery/privacy impact
+  - Reversible and auditable
+  - Scales governance before features
+  - Defensible under scrutiny (no false authority claims)
+- Cons:
+  - Requires user to remember to start session
+  - Less “magical” than always-on or predictive alternatives
+  - Slower escalation in truly unconscious emergencies
+
+## Decision
+
+**We will build the MVP as a session-bounded, human-escalation signaling layer only.**
+
+- No predictive risk scoring or behavioral inference
+- No continuous background monitoring
+- No autonomous contact with authorities or third parties
+- Escalation only to user-defined trusted contacts
+- All signals and logs are session-scoped and purpose-limited
+
+This decision is load-bearing: it reduces false authority, legal exposure, and irreversible coupling at the earliest stage.
+
+## Consequences
+
+- Positive
+  - Clear consent model (user starts/stops session)
+  - Lower privacy and battery concerns
+  - Easier to explain and defend in diligence, app store review, campus partnerships
+  - Governance and audit logic can evolve independently (externalized to AVC in Phase I)
+  - Future augmentation possible without contradicting MVP claims
+
+- Negative
+  - User must actively initiate protection mode
+  - No automatic detection of unconscious/high-risk states
+  - Marketing must avoid over-promising “AI” or “always-on” capabilities
+
+- Neutral / Trade-off
+  - Responsibility remains primarily with the user and their trusted circle
+  - Expansion to predictive or automated features requires explicit re-evaluation and new governance boundaries
+
+## References
+
+- TDC-01 Architecture Overview
+- TDC-01-ARCH-BD Boundary Decisions
+- TDC-01-ARCH-DR Design Rationale
+- Phase I Safety Signal Artifact ZIP v0.1 (non-production demo)
+
+## Related ADRs
+
+- (Future) ADR-XXX: Adding optional predictive routing layer (post-MVP, separate governance review required)

--- a/docs/adr/adr-004-data-minimization-strategy.md
+++ b/docs/adr/adr-004-data-minimization-strategy.md
@@ -1,0 +1,64 @@
+# ADR 004: Enforce strict data minimization and purpose limitation for all safety signals
+
+**Status**: Accepted  
+**Deciders**: Lilly Simpson (CEO), Engineering Lead, AVC Governance Consultant  
+**Consulted**: Privacy & Legal Advisor (external review)  
+**Informed**: Future investors, campus partners  
+**Date**: 2026-03-02
+
+## Context and Problem Statement
+
+The app collects location, check-in timestamps, and user-initiated signals during active safety sessions. Any unnecessary retention, secondary use, or over-collection creates disproportionate privacy risk, regulatory exposure (GDPR, CCPA, COPPA if under-18 users are possible), and liability in the event of a breach or subpoena.
+
+Competitors have faced scrutiny for indefinite location history, analytics misuse, or sharing with advertisers. We must design from day one to collect the absolute minimum data required for the core safety function.
+
+## Considered Options
+
+### Option 1: Collect full session telemetry + long-term analytics storage
+- Pros: Rich data for future ML improvements, usage insights, incident reconstruction
+- Cons: High privacy risk, large attack surface, difficult to justify necessity, violates data minimization principle
+
+### Option 2: Minimal retention per session, but cloud-sync everything for backup
+- Pros: Some redundancy, easier debugging
+- Cons: Unnecessary transmission of sensitive data, persistent cloud storage increases breach impact
+
+### Option 3: Session-scoped, client-side only retention with immediate deletion after session ends (Chosen)
+- Pros: Strongest minimization, explicit purpose limitation (safety signaling only), low breach impact, defensible under privacy laws
+- Cons: No historical analytics, harder post-mortem if incidents occur outside app, no cross-session patterns
+
+## Decision Outcome
+
+**Chosen option:** "Session-scoped, client-side only retention with immediate deletion after session ends"
+
+**Main reasons:**
+- Data minimization is a legal and ethical first principle for safety apps handling sensitive location data.
+- Purpose limitation: data exists only to enable real-time trusted-contact escalation.
+- Breach impact minimized: at most one active session per user is vulnerable.
+- Aligns with TDC-01 boundaries (minimal event log, no continuous surveillance).
+
+## Positive Consequences
+
+- Clear, defensible privacy story for app store review, campus partnerships, and user trust
+- Lower regulatory risk (easier Article 5 GDPR / CCPA §1798.100 compliance)
+- Smaller attack surface and faster incident response
+- Supports offline-first design (no cloud dependency for core function)
+
+## Negative Consequences
+
+- No long-term incident analytics or cross-user pattern detection
+- Debugging / support limited to live sessions or user-submitted evidence vault exports
+- Future ML features (if pursued) require explicit re-evaluation and new consent model
+
+## Risks & Mitigations
+
+- Risk: User loses important evidence if session ends prematurely  
+  Mitigation: Evidence Vault (encrypted, user-controlled export) remains available as opt-in Pro feature
+
+- Risk: Support team cannot assist without historical data  
+  Mitigation: Rely on user screenshots, vault exports, and session logs shared directly by user
+
+## More Information
+
+- Related ADRs: ADR 001 (Session-bounded signaling), ADR 003 (No cloud sync in MVP)
+- TDC-01-ARCH-BD Boundary 3: No Continuous Surveillance
+- Privacy-by-Design reference: NIST SP 800-53, OWASP Mobile Top 10 (M9 – Improper Session Handling)

--- a/docs/adr/adr-005-immediate-session-deletion.md
+++ b/docs/adr/adr-005-immediate-session-deletion.md
@@ -1,0 +1,32 @@
+# ADR 005: Delete all location and signal data immediately after session closure
+
+**Status**: Accepted  
+**Deciders**: Lilly Simpson, Tech Lead  
+**Date**: 2026-03-02
+
+## Context
+
+Location data is among the most sensitive categories collected by the app. Retaining it after the immediate safety need ends provides no ongoing user benefit while significantly increasing privacy and security risk.
+
+## Decision
+
+All location coordinates, timestamps, check-in signals, and associated metadata will be deleted from both client device and any temporary buffers within 5 minutes of session closure (user ends session or timeout occurs).
+
+Exceptions:
+- User explicitly exports to Evidence Vault (opt-in, encrypted, user-controlled)
+- Minimal anonymized success/failure counters for app health monitoring (no PII linkage)
+
+## Consequences
+
+Positive:
+- Drastically reduces data retention footprint
+- Strong alignment with data minimization principle
+- Easier to explain in privacy policy and campus outreach
+
+Negative:
+- Cannot offer historical “walk replay” or long-term safety insights
+- Support/debugging relies more on user cooperation
+
+Risks mitigated:
+- No long-lived location history to subpoena or leak
+- No temptation to monetize historical data

--- a/docs/adr/adr-006-evidence-vault-encryption.md
+++ b/docs/adr/adr-006-evidence-vault-encryption.md
@@ -1,0 +1,60 @@
+# ADR 006: Adopt end-to-end client-side encryption for Evidence Vault with user-controlled keys
+
+**Status**: Accepted  
+**Deciders**: Lilly Simpson (CEO), Engineering Lead, AVC Governance Consultant  
+**Consulted**: External Security & Privacy Advisor  
+**Informed**: Future investors, legal counsel, campus compliance partners  
+**Date**: 2026-03-03
+
+## Context and Problem Statement
+
+The Evidence Vault allows users to securely store photos, videos, voice notes, timestamps, and GPS metadata from safety incidents for potential future use (e.g., reporting to campus authorities, law enforcement, or personal records).
+
+This is among the most sensitive data the app will ever handle: visual/auditory evidence of harassment, assault, unsafe situations, or crimes. Any compromise (server breach, insider access, subpoena without user consent) could cause severe harm to users.
+
+Standard cloud storage with server-side encryption is common in competitor apps but fails to provide meaningful protection against provider access, compelled disclosure, or misconfiguration. We must design the Vault to survive a full server compromise while still being usable on mobile devices.
+
+## Considered Options
+
+### Option 1: Server-side encryption only (provider manages keys)
+- Pros: Simple implementation, easy recovery if user loses device, seamless cross-device sync
+- Cons: Provider (or government via subpoena) can access plaintext; single point of failure; violates meaningful end-to-end protection; weak privacy story for a safety app
+
+### Option 2: Hybrid — client encrypts, server stores encrypted blobs + recovery key escrow
+- Pros: Some user protection, possible account recovery
+- Cons: Escrow introduces trusted third-party risk; recovery key still allows compelled access; complex consent model
+
+### Option 3: Full client-side encryption with user-controlled keys, no server decryption capability (Chosen)
+- Description:
+  - All Vault content encrypted/decrypted exclusively on-device using keys derived from user passphrase or device-bound biometrics.
+  - Server stores only opaque encrypted blobs (no metadata readable by server).
+  - No backdoor, no recovery by app provider.
+  - Optional export to user-controlled locations (iCloud Drive, Google Drive, local files) for backup.
+- Pros:
+  - True end-to-end protection — even full server breach yields only ciphertext
+  - Strongest possible privacy and security posture
+  - Aligns with safety-app trust promise (“your evidence is yours alone”)
+  - Defensible under privacy laws and campus partner scrutiny
+  - Minimal server-side liability
+- Cons:
+  - User loses access if they forget passphrase / lose device without backup
+  - No automatic cross-device sync without user action
+  - Slightly higher UX friction (passphrase entry on access)
+
+## Decision Outcome
+
+**Chosen option:** "Full client-side encryption with user-controlled keys, no server decryption capability"
+
+## Positive Consequences
+
+- Extremely strong privacy narrative for marketing, app store review, campus partnerships
+- Reduced legal exposure for the company (no ability to produce plaintext even under court order)
+- Breach impact limited to metadata only (no content exposure)
+- Builds long-term user trust in a category where trust is fragile
+
+## Negative Consequences
+
+- Account recovery impossible without user-managed backups
+- Users must understand passphrase importance (onboarding education required)
+- Cross-device access requires manual export/import or cloud-drive sync (user responsibility)
+- Slightly increased implementation complexity (secure key derivation, secure enclave usage on iOS/Android)

--- a/docs/adr/adr-007-offline-first-evidence-vault.md
+++ b/docs/adr/adr-007-offline-first-evidence-vault.md
@@ -1,0 +1,40 @@
+# ADR 007: Adopt offline-first, local-only storage for Evidence Vault (no automatic cloud sync)
+
+**Status**: Accepted  
+**Deciders**: Lilly Simpson (CEO), Engineering Lead, AVC Governance Consultant  
+**Consulted**: External Security & Privacy Advisor  
+**Informed**: Future investors, legal counsel, campus compliance partners  
+**Date**: 2026-03-03
+
+## Context and Problem Statement
+
+The Evidence Vault is designed to let users securely capture and store photos, videos, voice notes, timestamps, and GPS metadata from safety incidents for potential future use (personal records, campus reports, law enforcement).
+
+This data is extremely sensitive. Automatic cloud upload/sync (even encrypted) introduces unacceptable risks at MVP stage: persistent server-side storage, compelled disclosure risk, metadata leakage, accidental sync to shared accounts, and internet dependency during high-stress moments.
+
+## Considered Options
+
+### Option 1: Automatic encrypted cloud sync
+- Pros: Seamless cross-device access, automatic backup, easier recovery
+- Cons: Data leaves device, metadata exposure, weakens strict minimization and user sovereignty
+
+### Option 2: Opt-in cloud backup after explicit user consent + manual export
+- Pros: Balances convenience with control
+- Cons: Still creates server-side presence; adds consent complexity and UX burden
+
+### Option 3: Fully offline-first, local-only storage with manual user export (Chosen)
+- Description:
+  - All Vault content stored exclusively on-device.
+  - No automatic upload or sync to any cloud service.
+  - Users can manually export Vault items to their own storage.
+- Pros:
+  - Zero server-side presence for Vault data
+  - Strong privacy and sovereignty posture
+  - No internet dependency during capture or review
+- Cons:
+  - No automatic cross-device access
+  - Risk of data loss without user backup
+
+## Decision Outcome
+
+**Chosen option:** "Fully offline-first, local-only storage with manual user export"

--- a/docs/adr/adr-008-vault-access-logging.md
+++ b/docs/adr/adr-008-vault-access-logging.md
@@ -1,0 +1,40 @@
+# ADR 008: Implement minimal, local-only, tamper-evident access logging for Evidence Vault
+
+**Status**: Accepted  
+**Deciders**: Lilly Simpson (CEO), Engineering Lead, AVC Governance Consultant  
+**Consulted**: External Security & Privacy Advisor  
+**Informed**: Future investors, legal counsel, campus compliance partners  
+**Date**: 2026-03-04
+
+## Context and Problem Statement
+
+The Evidence Vault stores highly sensitive user-generated content. Users and institutions may need to verify when the Vault was accessed, whether content was viewed/exported/modified, and whether a chain of custody remains intact.
+
+Full server-side logging is unacceptable due to centralization risk. No logging creates credibility gaps.
+
+## Considered Options
+
+### Option 1: No access logging
+- Pros: Maximum privacy
+- Cons: No chain-of-custody proof; weak evidentiary credibility
+
+### Option 2: Full server-side access logging
+- Pros: Centralized audit trail
+- Cons: Creates a sensitive centralized dataset; contradicts offline-first and minimization principles
+
+### Option 3: Minimal, local-only, tamper-evident logging inside encrypted Vault (Chosen)
+- Description:
+  - Append-only log entries stored inside the encrypted Vault.
+  - Entries record timestamp, action type, entry ID, and optional hashed device identifier.
+  - Entries are cryptographically chained for tamper detection.
+  - No log data leaves device unless user explicitly exports it.
+- Pros:
+  - Preserves offline-first client-side model
+  - Enables chain-of-custody verification without company access
+  - Minimal data footprint
+- Cons:
+  - Relies on device trust and user-managed export
+
+## Decision Outcome
+
+**Chosen option:** "Minimal, local-only, tamper-evident logging stored inside the encrypted Vault itself"

--- a/docs/adr/adr-009-vault-integrity-verification.md
+++ b/docs/adr/adr-009-vault-integrity-verification.md
@@ -1,0 +1,39 @@
+# ADR 009: Implement cryptographic integrity verification for Evidence Vault contents and access log
+
+**Status**: Accepted  
+**Deciders**: Lilly Simpson (CEO), Engineering Lead, AVC Governance Consultant  
+**Consulted**: External Security & Privacy Advisor  
+**Informed**: Future investors, legal counsel, campus compliance partners  
+**Date**: 2026-03-05
+
+## Context and Problem Statement
+
+Evidence Vault artifacts may be used for formal reports and legal processes. Users and third parties need to verify content has not been altered, access logs are authentic, and the full Vault maintains integrity over time.
+
+## Considered Options
+
+### Option 1: No integrity verification
+- Pros: Zero implementation effort
+- Cons: No tamper resistance; poor evidentiary value
+
+### Option 2: Server-side hashing/signatures on upload
+- Pros: Centralized attestation
+- Cons: Contradicts offline-first model; increases provider liability and metadata exposure
+
+### Option 3: Per-entry hashing + Merkle-tree root in signed Vault manifest (Chosen)
+- Description:
+  - Hash each Vault entry at capture time (SHA-256 or BLAKE3).
+  - Store hashes in append-only manifest; chain access log hashes.
+  - Build Merkle root and sign it with per-Vault key.
+  - Verification tool recomputes root and checks signature offline.
+- Pros:
+  - Detects tampering to content, metadata, and logs
+  - Preserves user-controlled, offline verification
+  - Minimal storage overhead
+- Cons:
+  - More implementation complexity
+  - Verification depends on key management and exports
+
+## Decision Outcome
+
+**Chosen option:** "Cryptographic per-entry hashing + Merkle-tree root stored in Vault manifest"


### PR DESCRIPTION
### Motivation

- Provide a concise, auditable set of Architecture Decision Records (ADRs) for privacy, consent, escalation, retention, and cryptographic integrity decisions relevant to the safety product and Evidence Vault.
- Make it easy for reviewers, auditors, and partners to find MADR-style decisions and the project’s ADR conventions in-repo.

### Description

- Add `docs/adr/README.md` containing ADR naming conventions and a MADR template for consistent authoring.
- Add ADRs documenting the chosen MVP boundaries and governance: `adr-001` (session-bounded human-escalation), `adr-004` (data minimization), `adr-005` (immediate session deletion), `adr-006` (client-side Evidence Vault encryption), `adr-007` (offline-first Vault storage), `adr-008` (local tamper-evident Vault access logging), and `adr-009` (cryptographic integrity verification / Merkle root manifest).
- Files are placed under `docs/adr/` and each ADR explains considered options, the decision outcome, consequences, and mitigations for implementers and reviewers.

### Testing

- Confirmed the ADR files exist with `find docs/adr -maxdepth 1 -type f | sort` and that the file list includes the new entries.
- Inspected content formatting and headings using `nl -ba docs/adr/*.md` to validate the MADR structure and included sections.
- Opened a PR using the repository’s PR helper (`make_pr`) which reported a successful PR creation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a543cc055c8330acd69aae659dd725)