### PR TITLE
feat(stageport-ui): add CodeVerter two‑pane code translation app (model‑agnostic)

### DIFF
--- a/stageport-ui/src/App.jsx
+++ b/stageport-ui/src/App.jsx
@@ -1,546 +1,473 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
-  Activity,
-  BarChart3,
-  CloudRain,
-  Database,
-  Fingerprint,
-  Flame,
-  Lock,
-  ShieldCheck,
-  Sun,
-  Terminal,
-  TrendingUp,
-  Unlock,
-  Wind,
-  Zap,
+  ArrowRightLeft,
+  Code2,
+  Copy,
+  Orbit,
+  RefreshCcw,
+  Search,
+  ShieldAlert,
+  Sparkles,
+  Wand2,
 } from 'lucide-react';
 
-const KILL_SWITCH_THRESHOLD = 0.35;
+const LANGUAGES = [
+  'Python',
+  'JavaScript',
+  'TypeScript',
+  'Java',
+  'C',
+  'C++',
+  'C#',
+  'Go',
+  'Rust',
+  'Swift',
+  'Kotlin',
+  'PHP',
+  'Ruby',
+  'R',
+  'Scala',
+  'Dart',
+  'Objective-C',
+  'Shell',
+  'SQL',
+  'MATLAB',
+  'Perl',
+  'Lua',
+  'Haskell',
+  'Elixir',
+  'Julia',
+];
 
-const clamp = (value, min = 0, max = 1) => Math.min(max, Math.max(min, value));
+const SAMPLE_SNIPPETS = {
+  JavaScript: `function fibonacci(n) {
+  if (n <= 1) return n;
+  return fibonacci(n - 1) + fibonacci(n - 2);
+}
+console.log(fibonacci(8));`,
+  Python: `def fibonacci(n):
+  if n <= 1:
+    return n
+  return fibonacci(n - 1) + fibonacci(n - 2)
 
-const calcRsi = (series, period = 14) => {
-  if (series.length <= period) {
-    return 50;
-  }
-
-  const window = series.slice(-period - 1);
-  let gains = 0;
-  let losses = 0;
-  for (let i = 1; i < window.length; i += 1) {
-    const delta = window[i].val - window[i - 1].val;
-    if (delta >= 0) {
-      gains += delta;
-    } else {
-      losses += Math.abs(delta);
-    }
-  }
-
-  if (losses === 0) {
-    return 100;
-  }
-
-  const rs = gains / losses;
-  return 100 - 100 / (1 + rs);
+print(fibonacci(8))`,
+  TypeScript: `type User = {
+  id: number;
+  name: string;
 };
 
-const App = () => {
-  const [pVal, setPVal] = useState(0.032);
-  const [weight, setWeight] = useState(92);
-  const [ciStatus] = useState('Excludes 0');
-  const [ciRange] = useState({ lower: 1.2, upper: 5.8 });
-  const [isLive] = useState(true);
+function greet(user: User): string {
+  return \`Hello, \${user.name}\`;
+}
 
-  const [rainIntensity, setRainIntensity] = useState(0.78);
-  const [sunIntensity, setSunIntensity] = useState(0.35);
-  const [lightningIntensity, setLightningIntensity] = useState(0.44);
+console.log(greet({ id: 1, name: "Allison" }));`,
+};
 
-  const [signalHistory, setSignalHistory] = useState(() =>
-    Array.from({ length: 40 }, (_, i) => ({
-      val: 2.5 + Math.sin(i / 5) + Math.random() * 0.35,
-      rain: clamp(0.65 + Math.sin(i / 6) * 0.2 + (Math.random() - 0.5) * 0.1),
-      sun: clamp(0.4 + Math.cos(i / 4) * 0.25 + (Math.random() - 0.5) * 0.1),
-      lightning: clamp(0.3 + Math.sin(i / 3) * 0.3 + (Math.random() - 0.5) * 0.15),
-      time: i,
-    })),
-  );
+const MODES = [
+  {
+    key: 'standard',
+    label: 'Standard',
+    icon: Wand2,
+    description: 'Direct language conversion with equivalent logic and idioms.',
+  },
+  {
+    key: 'signal',
+    label: 'Signal Mode',
+    icon: Sparkles,
+    description: 'Adds concise narrative insight about architectural intent.',
+  },
+  {
+    key: 'cipher',
+    label: 'Cipher Mode',
+    icon: ShieldAlert,
+    description: 'Highlights hidden patterns, assumptions, and risky translations.',
+  },
+  {
+    key: 'echo',
+    label: 'Echo Mode',
+    icon: Orbit,
+    description: 'Generates follow-up suggestions, tests, and next-step prompts.',
+  },
+];
 
-  const [logs, setLogs] = useState([
-    { t: '03:44:01', m: 'AUTH_KEY verified', type: 'success' },
-    { t: '03:44:12', m: 'Initializing block bootstrap engine...', type: 'info' },
-    { t: '03:44:15', m: 'n_boot=1000 resamples complete.', type: 'success' },
-    { t: '03:44:18', m: 'τ* detected at Lag -4.', type: 'info' },
-    { t: '03:44:20', m: 'CI: [1.2, 5.8] (Excludes 0)', type: 'success' },
-  ]);
+const classNames = (...values) => values.filter(Boolean).join(' ');
 
-  const [brierScore, setBrierScore] = useState(0.18);
-  const [tradeLog, setTradeLog] = useState([]);
-  const [sentimentData, setSentimentData] = useState({ buzzIntensity: 62, tilt: 0.22 });
+function LanguageAutocomplete({ label, value, onChange, placeholder = 'Search language...' }) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState(value || '');
 
-  const isStructuralConfirmed = weight >= 80;
-  const isCiValid = ciStatus === 'Excludes 0';
-  const isPValuePass = pVal < 0.05;
-  const isRegimeOpen = isStructuralConfirmed && isCiValid && isPValuePass;
-  const killSwitchTriggered = brierScore > KILL_SWITCH_THRESHOLD;
-
-  const recommendations = useMemo(
-    () => [
-      { signal: 'RAIN', confidence: rainIntensity, color: 'text-blue-400', bg: 'bg-blue-500/15' },
-      { signal: 'SUN', confidence: sunIntensity, color: 'text-amber-400', bg: 'bg-amber-500/15' },
-      { signal: 'ZAP', confidence: lightningIntensity, color: 'text-rose-400', bg: 'bg-rose-500/15' },
-      {
-        signal: 'HEDGE',
-        confidence: clamp(1 - (sunIntensity + lightningIntensity) / 2),
-        color: 'text-violet-400',
-        bg: 'bg-violet-500/15',
-      },
-    ],
-    [rainIntensity, sunIntensity, lightningIntensity],
-  );
-
-  const completedTrades = tradeLog.filter((trade) => trade.outcome !== null);
-  const wins = completedTrades.filter((trade) => trade.outcome > 0).length;
-  const losses = completedTrades.filter((trade) => trade.outcome <= 0).length;
-  const cumulativePnl = completedTrades.reduce((acc, trade) => acc + trade.outcome, 0);
-  const missedOpportunities = completedTrades.filter((trade) => trade.regret > 0).length;
-  const rsi = calcRsi(signalHistory);
-  const latestSignal = signalHistory[signalHistory.length - 1]?.val ?? 0;
-  const atr = 0.18;
-  const upperBand = latestSignal + atr;
-  const lowerBand = latestSignal - atr;
-
-  const actionFor = (asset) => {
-    if (asset === 'QQQ') {
-      return 'MONITOR';
+  const filtered = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) {
+      return LANGUAGES;
     }
 
-    if (asset === 'ETH') {
-      return isRegimeOpen ? 'SCALED ENTRY' : 'CONFIRM (NO ENTRY)';
-    }
+    return LANGUAGES.filter((language) => language.toLowerCase().includes(normalized));
+  }, [query]);
 
-    return isRegimeOpen ? 'SCALED ENTRY' : 'OBSERVE ONLY';
+  const selectLanguage = (language) => {
+    setQuery(language);
+    onChange(language);
+    setOpen(false);
   };
 
-  const assetData = useMemo(
-    () => [
-      {
-        asset: 'LIT',
-        pivot: 72.15,
-        s1: 71.39,
-        s2: 70.83,
-        r1: 73.47,
-        r2: 74.57,
-      },
-      {
-        asset: 'ETH',
-        pivot: 1981.96,
-        s1: 1944.13,
-        s2: 1902.62,
-        r1: 2023.47,
-        r2: 2061.3,
-      },
-      {
-        asset: 'QQQ',
-        pivot: 601.61,
-        s1: 596.75,
-        s2: 591.59,
-        r1: 606.77,
-        r2: 611.63,
-      },
-    ],
-    [],
-  );
+  return (
+    <div className="relative">
+      <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">{label}</label>
 
-  const executeTrade = (signal, confidence) => {
-    if (killSwitchTriggered) {
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+        <input
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          onBlur={() => {
+            window.setTimeout(() => {
+              setOpen(false);
+
+              const exactMatch = LANGUAGES.find(
+                (language) => language.toLowerCase() === query.trim().toLowerCase(),
+              );
+
+              if (exactMatch) {
+                setQuery(exactMatch);
+                onChange(exactMatch);
+              } else if (!query.trim() && value) {
+                setQuery(value);
+              }
+            }, 120);
+          }}
+          placeholder={placeholder}
+          className="w-full rounded-2xl border border-slate-200 bg-white py-3 pl-10 pr-4 text-sm text-slate-900 shadow-sm outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-200"
+        />
+      </div>
+
+      {open && (
+        <div className="absolute z-20 mt-2 max-h-64 w-full overflow-auto rounded-2xl border border-slate-200 bg-white p-2 shadow-xl">
+          {filtered.length > 0 ? (
+            filtered.map((language) => (
+              <button
+                key={language}
+                type="button"
+                onClick={() => selectLanguage(language)}
+                className={classNames(
+                  'flex w-full items-center justify-between rounded-xl px-3 py-2 text-left text-sm transition',
+                  value === language ? 'bg-slate-900 text-white' : 'text-slate-700 hover:bg-slate-100',
+                )}
+              >
+                <span>{language}</span>
+                {value === language && <span className="text-xs opacity-80">Selected</span>}
+              </button>
+            ))
+          ) : (
+            <div className="rounded-xl px-3 py-3 text-sm text-slate-500">No language match.</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ModeCard({ mode, active, onClick }) {
+  const Icon = mode.icon;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={classNames(
+        'rounded-2xl border p-4 text-left transition',
+        active
+          ? 'border-slate-900 bg-slate-900 text-white shadow-lg'
+          : 'border-slate-200 bg-white text-slate-800 hover:border-slate-300 hover:bg-slate-50',
+      )}
+    >
+      <div className="mb-2 flex items-center gap-2">
+        <Icon className="h-4 w-4" />
+        <span className="text-sm font-semibold">{mode.label}</span>
+      </div>
+      <p className={classNames('text-xs leading-5', active ? 'text-slate-200' : 'text-slate-500')}>
+        {mode.description}
+      </p>
+    </button>
+  );
+}
+
+function buildConversionPrompt({ sourceLanguage, targetLanguage, sourceCode, mode }) {
+  const modeInstructions = {
+    standard:
+      'Return only the translated code. Preserve business logic, improve syntax correctness, and use idiomatic constructs for the target language.',
+    signal:
+      "Return the translated code first, then add a short section titled 'Signal Notes' with 3 bullet points explaining architectural intent and notable translation choices.",
+    cipher:
+      "Return the translated code first, then add a short section titled 'Cipher Notes' with 3 bullet points calling out hidden assumptions, risky mappings, edge cases, or areas that need manual review.",
+    echo:
+      "Return the translated code first, then add a short section titled 'Echo Notes' with 3 bullet points suggesting tests, refactors, or next-step prompts for the developer.",
+  };
+
+  return `You are an expert multilingual software engineer.
+Task: Convert code from ${sourceLanguage} to ${targetLanguage}.
+Rules:
+- Preserve the original logic and intent.
+- Use idiomatic ${targetLanguage} syntax and conventions.
+- Do not explain every line.
+- Do not invent features that are not present.
+- If the source code is incomplete, make the smallest valid assumptions.
+- ${modeInstructions[mode]}
+Source language: ${sourceLanguage}
+Target language: ${targetLanguage}
+Source code:\n\n${sourceCode}`;
+}
+
+async function requestTranslation({ sourceLanguage, targetLanguage, sourceCode, mode, endpoint, apiKey }) {
+  const prompt = buildConversionPrompt({ sourceLanguage, targetLanguage, sourceCode, mode });
+
+  if (!endpoint) {
+    return `// Demo mode: no model endpoint configured\n// Source: ${sourceLanguage}\n// Target: ${targetLanguage}\n// Mode: ${MODES.find((item) => item.key === mode)?.label}\n\n/*
+Plug your own model endpoint into Settings to perform real translation.
+Suggested backend contract:
+POST /api/convert
+{
+  "sourceLanguage": "${sourceLanguage}",
+  "targetLanguage": "${targetLanguage}",
+  "mode": "${mode}",
+  "prompt": "..."
+}
+*/\n\n${sourceCode}`;
+  }
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+    },
+    body: JSON.stringify({
+      sourceLanguage,
+      targetLanguage,
+      mode,
+      prompt,
+      sourceCode,
+    }),
+  });
+
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(details || 'Translation request failed.');
+  }
+
+  const data = await response.json();
+  return data.output || data.result || data.code || '';
+}
+
+export default function App() {
+  const [sourceLanguage, setSourceLanguage] = useState('JavaScript');
+  const [targetLanguage, setTargetLanguage] = useState('Python');
+  const [sourceCode, setSourceCode] = useState(SAMPLE_SNIPPETS.JavaScript);
+  const [translatedCode, setTranslatedCode] = useState('');
+  const [mode, setMode] = useState('standard');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [endpoint, setEndpoint] = useState('');
+  const [apiKey, setApiKey] = useState('');
+
+  const canConvert =
+    sourceCode.trim() && sourceLanguage && targetLanguage && sourceLanguage !== targetLanguage;
+
+  const swapLanguages = () => {
+    const previousSourceLanguage = sourceLanguage;
+    const previousSourceCode = sourceCode;
+
+    setSourceLanguage(targetLanguage);
+    setTargetLanguage(previousSourceLanguage);
+    setSourceCode(translatedCode || previousSourceCode);
+    setTranslatedCode(previousSourceCode);
+  };
+
+  const loadSample = () => {
+    const sample = SAMPLE_SNIPPETS[sourceLanguage] || SAMPLE_SNIPPETS.JavaScript;
+    setSourceCode(sample);
+  };
+
+  const handleConvert = async () => {
+    setLoading(true);
+    setError('');
+
+    try {
+      const output = await requestTranslation({
+        sourceLanguage,
+        targetLanguage,
+        sourceCode,
+        mode,
+        endpoint,
+        apiKey,
+      });
+
+      setTranslatedCode(output);
+    } catch (err) {
+      setError(err?.message || 'Something failed during conversion.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const copyOutput = async () => {
+    if (!translatedCode) {
       return;
     }
 
-    const edge = confidence - (1 - confidence);
-    const kellySize = clamp(edge, 0, 0.25);
-    const outcome = Number(((Math.random() - 0.45) * 2.2).toFixed(2));
-    const regret = Number(Math.max(0, confidence * 1.2 - outcome).toFixed(2));
-
-    const trade = {
-      id: Date.now(),
-      signal,
-      confidence,
-      kellySize,
-      timestamp: new Date().toLocaleTimeString('en-US', { hour12: false }),
-      outcome,
-      regret,
-    };
-
-    setTradeLog((prev) => [trade, ...prev].slice(0, 12));
+    await navigator.clipboard.writeText(translatedCode);
   };
 
-  useEffect(() => {
-    if (!isLive) {
-      return undefined;
-    }
-
-    const pollInterval = setInterval(() => {
-      setSignalHistory((prev) => {
-        const nextVal = prev[prev.length - 1].val + (Math.random() - 0.5) * 0.35;
-        const next = {
-          val: nextVal,
-          rain: clamp(rainIntensity + (Math.random() - 0.5) * 0.08),
-          sun: clamp(sunIntensity + (Math.random() - 0.5) * 0.08),
-          lightning: clamp(lightningIntensity + (Math.random() - 0.5) * 0.1),
-          time: Date.now(),
-        };
-
-        setRainIntensity(next.rain);
-        setSunIntensity(next.sun);
-        setLightningIntensity(next.lightning);
-
-        return [...prev.slice(1), next];
-      });
-
-      setSentimentData((prev) => ({
-        buzzIntensity: Math.max(1, Math.round(prev.buzzIntensity + (Math.random() - 0.5) * 12)),
-        tilt: clamp(prev.tilt + (Math.random() - 0.5) * 0.18, -1, 1),
-      }));
-
-      setBrierScore((prev) => clamp(prev + (Math.random() - 0.5) * 0.03, 0.02, 0.65));
-
-      if (Math.random() > 0.8) {
-        const now = new Date().toLocaleTimeString('en-US', { hour12: false });
-        const msgs = ['Regime status verified.', 'Heartbeat active.', 'Signal audit complete.'];
-        setLogs((prev) => [
-          { t: now, m: msgs[Math.floor(Math.random() * msgs.length)], type: 'info' },
-          ...prev.slice(0, 8),
-        ]);
-      }
-    }, 3000);
-
-    return () => clearInterval(pollInterval);
-  }, [isLive, lightningIntensity, rainIntensity, sunIntensity]);
-
   return (
-    <div className="min-h-screen bg-slate-950 text-slate-200 font-sans selection:bg-emerald-500/30">
-      <header className="border-b border-slate-800 bg-slate-900/50 backdrop-blur-md sticky top-0 z-50">
-        <div className="max-w-[1600px] mx-auto px-4 h-16 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <div className="bg-emerald-500 p-2 rounded shadow-[0_0_15px_rgba(16,185,129,0.3)]">
-              <ShieldCheck className="w-5 h-5 text-slate-950" />
-            </div>
+    <div className="min-h-screen bg-slate-100 text-slate-900">
+      <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mb-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
             <div>
-              <h1 className="text-lg font-bold tracking-tight text-white uppercase flex items-center gap-2">
-                PRIMA Fortress Dashboard
-                <span className="text-xs bg-slate-800 px-2 py-0.5 rounded text-emerald-400 font-mono">v2.2</span>
-              </h1>
+              <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                <Code2 className="h-3.5 w-3.5" />
+                Code translation workspace
+              </div>
+              <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">CodeVerter</h1>
+              <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600 sm:text-base">
+                Convert code from one language to another with a model-agnostic pipeline. Plug in any
+                backend that accepts a prompt and returns translated code.
+              </p>
+            </div>
+
+            <div className="grid w-full max-w-xl gap-3 sm:grid-cols-2">
+              <div>
+                <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                  Model endpoint
+                </label>
+                <input
+                  value={endpoint}
+                  onChange={(event) => setEndpoint(event.target.value)}
+                  placeholder="https://your-domain.com/api/convert"
+                  className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-200"
+                />
+              </div>
+
+              <div>
+                <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                  API key optional
+                </label>
+                <input
+                  value={apiKey}
+                  onChange={(event) => setApiKey(event.target.value)}
+                  placeholder="Bearer token if needed"
+                  className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm shadow-sm outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-200"
+                />
+              </div>
             </div>
           </div>
+        </div>
 
-          <div className="flex items-center gap-2 text-xs font-semibold">
-            <span className="text-slate-500">KILL SWITCH</span>
-            <span
-              className={`px-3 py-1 rounded-full border font-mono ${
-                killSwitchTriggered
-                  ? 'bg-rose-500/10 border-rose-500/50 text-rose-300'
-                  : 'bg-emerald-500/10 border-emerald-500/50 text-emerald-300'
-              }`}
+        <div className="mb-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {MODES.map((item) => (
+            <ModeCard key={item.key} mode={item} active={mode === item.key} onClick={() => setMode(item.key)} />
+          ))}
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-[1fr_auto_1fr]">
+          <section className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+            <div className="mb-4 flex items-center justify-between gap-3">
+              <h2 className="text-lg font-semibold">Source</h2>
+              <button
+                type="button"
+                onClick={loadSample}
+                className="rounded-xl border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+              >
+                Load sample
+              </button>
+            </div>
+
+            <LanguageAutocomplete
+              label="From language"
+              value={sourceLanguage}
+              onChange={setSourceLanguage}
+            />
+
+            <div className="mt-4">
+              <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                Input code
+              </label>
+              <textarea
+                value={sourceCode}
+                onChange={(event) => setSourceCode(event.target.value)}
+                spellCheck={false}
+                placeholder="Paste or write source code here..."
+                className="min-h-[520px] w-full rounded-2xl border border-slate-200 bg-slate-950 p-4 font-mono text-sm leading-6 text-slate-100 shadow-inner outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-200"
+              />
+            </div>
+          </section>
+
+          <div className="flex flex-row items-center justify-center xl:flex-col">
+            <button
+              type="button"
+              onClick={swapLanguages}
+              className="inline-flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-semibold text-slate-800 shadow-sm transition hover:bg-slate-50"
             >
-              {killSwitchTriggered ? 'TRADING HALTED' : 'TRADING ENABLED'}
-            </span>
-          </div>
-        </div>
-      </header>
+              <RefreshCcw className="h-4 w-4" />
+              Swap
+            </button>
 
-      <main className="max-w-[1600px] mx-auto p-4 lg:p-6 grid grid-cols-12 gap-6">
-        <div className="col-span-12 lg:col-span-3 space-y-6">
-          <section className="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden shadow-xl">
-            <div className="px-4 py-3 border-b border-slate-800 bg-slate-800/30">
-              <h2 className="text-xs font-bold uppercase tracking-wider flex items-center gap-2">
-                <Fingerprint className="w-3.5 h-3.5 text-emerald-500" /> Origin Audit
-              </h2>
-            </div>
-            <div className="p-4 bg-slate-950/50 text-[10px] font-mono space-y-2">
-              <div className="flex justify-between">
-                <span className="text-slate-600 uppercase">Provider</span>
-                <span className="text-slate-300">AVCSYSTEMSSTUDIOS</span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-slate-600 uppercase">Identity</span>
-                <span className="text-emerald-500">@xoAVCxo</span>
-              </div>
-            </div>
-          </section>
-
-          <section className="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden shadow-xl">
-            <div className="px-4 py-3 border-b border-slate-800 bg-slate-800/30">
-              <h2 className="text-xs font-bold uppercase tracking-wider flex items-center gap-2 text-slate-400">
-                <Terminal className="w-3.5 h-3.5" /> Filters
-              </h2>
-            </div>
-            <div className="p-5 space-y-6">
-              <div className="space-y-3">
-                <div className="flex justify-between items-end text-[11px] uppercase text-slate-500 font-semibold tracking-wider">
-                  <span>P-Value</span>
-                  <span className={`text-lg font-mono font-bold ${isPValuePass ? 'text-emerald-400' : 'text-rose-400'}`}>
-                    {pVal.toFixed(3)}
-                  </span>
-                </div>
-                <input
-                  type="range"
-                  min="0"
-                  max="0.1"
-                  step="0.001"
-                  value={pVal}
-                  onChange={(e) => setPVal(parseFloat(e.target.value))}
-                  className="w-full h-1.5 bg-slate-800 rounded-lg appearance-none cursor-pointer accent-emerald-500"
-                />
-              </div>
-
-              <div className="space-y-3">
-                <div className="flex justify-between items-end text-[11px] uppercase text-slate-500 font-semibold tracking-wider">
-                  <span>Weight (W)</span>
-                  <span className={`text-lg font-mono font-bold ${isStructuralConfirmed ? 'text-emerald-400' : 'text-rose-400'}`}>
-                    {weight}
-                  </span>
-                </div>
-                <input
-                  type="number"
-                  value={weight}
-                  onChange={(e) => setWeight(parseInt(e.target.value, 10) || 0)}
-                  className="w-full bg-slate-950 border border-slate-800 rounded p-2 text-white font-mono text-sm"
-                />
-              </div>
-              <div className="space-y-3">
-                <div className="flex justify-between items-end text-[11px] uppercase text-slate-500 font-semibold tracking-wider">
-                  <span>Brier Score</span>
-                  <span className={`text-lg font-mono font-bold ${killSwitchTriggered ? 'text-rose-400' : 'text-emerald-400'}`}>
-                    {brierScore.toFixed(3)}
-                  </span>
-                </div>
-                <input
-                  type="range"
-                  min="0"
-                  max="0.6"
-                  step="0.001"
-                  value={brierScore}
-                  onChange={(e) => setBrierScore(parseFloat(e.target.value))}
-                  className="w-full h-1.5 bg-slate-800 rounded-lg appearance-none cursor-pointer accent-violet-400"
-                />
-              </div>
-            </div>
-          </section>
-
-          <section className="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden shadow-xl h-[300px] flex flex-col">
-            <div className="px-4 py-3 border-b border-slate-800 bg-slate-800/30">
-              <h2 className="text-xs font-bold uppercase tracking-wider flex items-center gap-2">
-                <Activity className="w-3.5 h-3.5 text-blue-500" /> Engine Logs
-              </h2>
-            </div>
-            <div className="flex-1 overflow-y-auto p-4 font-mono text-[10px] space-y-1.5">
-              {logs.map((log, i) => (
-                <div key={i} className="flex gap-2 leading-tight">
-                  <span className="text-slate-600">[{log.t}]</span>
-                  <span className={log.type === 'success' ? 'text-emerald-400' : 'text-slate-400'}>{log.m}</span>
-                </div>
-              ))}
-            </div>
-          </section>
-        </div>
-
-        <div className="col-span-12 lg:col-span-9 space-y-6">
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-            {[
-              {
-                label: 'Structural Status',
-                value: isStructuralConfirmed ? `CONFIRMED (W=${weight})` : 'UNCONFIRMED',
-                icon: Database,
-              },
-              {
-                label: 'Confidence Int.',
-                value: ciStatus,
-                sub: `Range: [${ciRange.lower}, ${ciRange.upper}]`,
-                icon: Zap,
-              },
-              {
-                label: 'Significance',
-                value: isPValuePass ? 'SIG PASS' : 'NO EDGE',
-                sub: 'Target < 0.05',
-                icon: BarChart3,
-              },
-              {
-                label: 'Sentiment Tilt',
-                value: sentimentData.tilt >= 0 ? 'BULLISH' : 'BEARISH',
-                sub: `${sentimentData.tilt >= 0 ? '+' : ''}${(sentimentData.tilt * 100).toFixed(1)}%`,
-                icon: Flame,
-              },
-            ].map((stat, i) => (
-              <div key={i} className="bg-slate-900 border border-slate-800 p-5 rounded-xl relative overflow-hidden">
-                <div className="absolute top-0 right-0 p-4 opacity-5">
-                  <stat.icon className="w-10 h-10" />
-                </div>
-                <span className="text-[10px] text-slate-500 font-bold uppercase tracking-wider">{stat.label}</span>
-                <div className={`text-lg font-mono font-bold mt-1 ${isRegimeOpen ? 'text-emerald-400' : 'text-slate-300'}`}>
-                  {stat.value}
-                </div>
-                {stat.sub && <div className="text-[10px] text-slate-600 font-mono mt-1 italic">{stat.sub}</div>}
-              </div>
-            ))}
+            <button
+              type="button"
+              disabled={!canConvert || loading}
+              onClick={handleConvert}
+              className={classNames(
+                'mt-3 inline-flex items-center gap-2 rounded-2xl px-5 py-3 text-sm font-semibold shadow-sm transition xl:mt-4',
+                !canConvert || loading
+                  ? 'cursor-not-allowed bg-slate-300 text-slate-500'
+                  : 'bg-slate-900 text-white hover:bg-slate-800',
+              )}
+            >
+              <ArrowRightLeft className="h-4 w-4" />
+              {loading ? 'Converting...' : 'Convert Code'}
+            </button>
           </div>
 
-          <section className="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden shadow-xl p-6">
-            <h2 className="text-xs font-bold uppercase tracking-wider flex items-center gap-2 text-slate-300 mb-6">
-              <TrendingUp className="w-3.5 h-3.5 text-purple-500" /> Advanced Signal Telemetry
-            </h2>
-            <div className="h-44 w-full">
-              <svg className="w-full h-full overflow-visible" preserveAspectRatio="none" viewBox="0 0 1000 120">
-                <line x1="0" x2="1000" y1={100 - upperBand * 20} y2={100 - upperBand * 20} stroke="#a78bfa" strokeDasharray="4 4" opacity="0.65" />
-                <line x1="0" x2="1000" y1={100 - lowerBand * 20} y2={100 - lowerBand * 20} stroke="#a78bfa" strokeDasharray="4 4" opacity="0.65" />
-                <path
-                  d={`M ${signalHistory
-                    .map((d, i) => `${(i / (signalHistory.length - 1)) * 1000},${100 - d.val * 20}`)
-                    .join(' L ')}`}
-                  fill="none"
-                  stroke={isRegimeOpen ? '#10b981' : '#475569'}
-                  strokeWidth="2"
-                  vectorEffect="non-scaling-stroke"
-                />
-                <path
-                  d={`M ${signalHistory
-                    .map((d, i) => `${(i / (signalHistory.length - 1)) * 1000},${112 - d.lightning * 35}`)
-                    .join(' L ')}`}
-                  fill="none"
-                  stroke="#f43f5e"
-                  strokeWidth="1.6"
-                  opacity="0.85"
-                />
-              </svg>
-            </div>
-            <div className="mt-4 grid grid-cols-2 md:grid-cols-4 gap-3 text-xs font-mono">
-              <div className="bg-slate-950 border border-slate-800 rounded-lg p-3 flex items-center gap-2">
-                <CloudRain className="w-4 h-4 text-blue-400" /> RAIN {(rainIntensity * 100).toFixed(0)}%
-              </div>
-              <div className="bg-slate-950 border border-slate-800 rounded-lg p-3 flex items-center gap-2">
-                <Sun className="w-4 h-4 text-amber-300" /> SUN {(sunIntensity * 100).toFixed(0)}%
-              </div>
-              <div className="bg-slate-950 border border-slate-800 rounded-lg p-3 flex items-center gap-2">
-                <Zap className="w-4 h-4 text-rose-400" /> ZAP {(lightningIntensity * 100).toFixed(0)}%
-              </div>
-              <div className="bg-slate-950 border border-slate-800 rounded-lg p-3 flex items-center gap-2">
-                <Wind className="w-4 h-4 text-violet-300" /> RSI {rsi.toFixed(1)}
-              </div>
-            </div>
-          </section>
-
-          <section className="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden shadow-xl p-6">
-            <h2 className="text-xs font-bold uppercase tracking-wider text-white mb-4">Trade Execution Panel</h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div className="space-y-3">
-                {recommendations.map((rec) => (
-                  <div key={rec.signal} className={`flex items-center justify-between rounded-lg border border-slate-700 ${rec.bg} px-3 py-2`}>
-                    <div>
-                      <div className="text-[11px] uppercase text-slate-400">{rec.signal} Signal</div>
-                      <div className={`font-mono font-bold ${rec.color}`}>Confidence {(rec.confidence * 100).toFixed(1)}%</div>
-                    </div>
-                    <button
-                      onClick={() => executeTrade(rec.signal, rec.confidence)}
-                      disabled={killSwitchTriggered}
-                      className="px-3 py-1.5 rounded bg-slate-800 border border-slate-700 text-xs uppercase disabled:opacity-40"
-                    >
-                      Execute
-                    </button>
-                  </div>
-                ))}
-              </div>
-              <div className="bg-slate-950 border border-slate-800 rounded-lg p-4">
-                <div className="text-[11px] uppercase text-slate-500 mb-2">Recent Trades (Kelly Sizing)</div>
-                <ul className="space-y-1 text-xs font-mono max-h-48 overflow-y-auto pr-1">
-                  {tradeLog.length === 0 && <li className="text-slate-500">No simulated trades yet.</li>}
-                  {tradeLog.map((trade) => (
-                    <li key={trade.id} className="text-slate-300">
-                      {trade.timestamp} • {trade.signal} • Conf {trade.confidence.toFixed(2)} • Kelly {(trade.kellySize * 100).toFixed(1)}% • PnL{' '}
-                      <span className={trade.outcome >= 0 ? 'text-emerald-400' : 'text-rose-400'}>{trade.outcome.toFixed(2)}</span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </div>
-          </section>
-
-          <section className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="bg-slate-900 border border-slate-800 rounded-xl p-5">
-              <h2 className="text-xs font-bold uppercase tracking-wider text-white mb-3">Historical Performance</h2>
-              <div className="space-y-2 font-mono text-sm">
-                <div className="flex justify-between"><span className="text-slate-400">Win/Loss Ratio</span><span>{wins}:{losses}</span></div>
-                <div className="flex justify-between">
-                  <span className="text-slate-400">Cumulative PnL</span>
-                  <span className={cumulativePnl >= 0 ? 'text-emerald-400' : 'text-rose-400'}>{cumulativePnl.toFixed(2)}</span>
-                </div>
-                <div className="flex justify-between"><span className="text-slate-400">Regret Events</span><span>{missedOpportunities}</span></div>
-              </div>
+          <section className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+            <div className="mb-4 flex items-center justify-between gap-3">
+              <h2 className="text-lg font-semibold">Output</h2>
+              <button
+                type="button"
+                onClick={copyOutput}
+                className="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+              >
+                <Copy className="h-4 w-4" />
+                Copy
+              </button>
             </div>
 
-            <div className="bg-slate-900 border border-slate-800 rounded-xl p-5">
-              <h2 className="text-xs font-bold uppercase tracking-wider text-white mb-3">Sentiment Analysis Overlay</h2>
-              <div className="space-y-3">
-                <div>
-                  <div className="flex justify-between text-xs text-slate-400 mb-1"><span>Buzz Intensity</span><span>{sentimentData.buzzIntensity}</span></div>
-                  <div className="h-2 rounded bg-slate-800 overflow-hidden">
-                    <div className="h-full bg-cyan-400" style={{ width: `${Math.min(sentimentData.buzzIntensity, 100)}%` }} />
-                  </div>
-                </div>
-                <div className="flex justify-between items-center text-sm font-mono">
-                  <span className="text-slate-400">Sentiment Tilt</span>
-                  <span className={sentimentData.tilt >= 0 ? 'text-emerald-400' : 'text-rose-400'}>
-                    {sentimentData.tilt >= 0 ? 'Bullish' : 'Bearish'} ({(sentimentData.tilt * 100).toFixed(1)}%)
-                  </span>
-                </div>
-              </div>
-            </div>
-          </section>
+            <LanguageAutocomplete label="To language" value={targetLanguage} onChange={setTargetLanguage} />
 
-          <section className="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden shadow-xl">
-            <div className="px-4 py-4 border-b border-slate-800 bg-slate-800/30">
-              <h2 className="text-xs font-bold uppercase tracking-wider text-white">Institutional Day Sheet</h2>
+            <div className="mt-4">
+              <label className="mb-2 block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                Translated code
+              </label>
+              <textarea
+                value={translatedCode}
+                onChange={(event) => setTranslatedCode(event.target.value)}
+                spellCheck={false}
+                placeholder="Converted code will appear here..."
+                className="min-h-[520px] w-full rounded-2xl border border-slate-200 bg-slate-950 p-4 font-mono text-sm leading-6 text-emerald-100 shadow-inner outline-none transition focus:border-slate-400 focus:ring-2 focus:ring-slate-200"
+              />
             </div>
-            <table className="w-full text-left border-collapse font-mono text-xs">
-              <thead>
-                <tr className="bg-slate-950/50 text-[10px] uppercase text-slate-500 border-b border-slate-800">
-                  <th className="px-4 py-3">Asset</th>
-                  <th className="px-4 py-3">Pivot</th>
-                  <th className="px-4 py-3">S1 / S2</th>
-                  <th className="px-4 py-3">R1 / R2</th>
-                  <th className="px-4 py-3">Action Rule</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-slate-800">
-                {assetData.map((row, i) => (
-                  <tr key={i} className="hover:bg-slate-800/20">
-                    <td className="px-4 py-4 font-bold">{row.asset}</td>
-                    <td className="px-4 py-4">{row.pivot.toFixed(2)}</td>
-                    <td className="px-4 py-4 text-rose-400">
-                      {row.s1.toFixed(2)} / {row.s2.toFixed(2)}
-                    </td>
-                    <td className="px-4 py-4 text-emerald-400">
-                      {row.r1.toFixed(2)} / {row.r2.toFixed(2)}
-                    </td>
-                    <td className="px-4 py-4">
-                      <span
-                        className={`px-2 py-0.5 rounded text-[10px] uppercase font-bold ${
-                          actionFor(row.asset).includes('ENTRY')
-                            ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20'
-                            : 'bg-slate-800 text-slate-500'
-                        }`}
-                      >
-                        {actionFor(row.asset)}
-                      </span>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
           </section>
         </div>
-      </main>
+
+        {error && (
+          <div className="mt-6 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700 shadow-sm">
+            {error}
+          </div>
+        )}
+      </div>
     </div>
   );
-};
-
-export default App;
+}


### PR DESCRIPTION
### Motivation
- Replace an existing dashboard view with a focused developer utility that converts code between major languages and is backend‑agnostic.
- Provide a production‑ready UI and prompt pipeline that can be pointed at any model endpoint instead of hardwiring Anthropic/Claude.

### Description
- Replaced the previous dashboard implementation with the `CodeVerter` app in `stageport-ui/src/App.jsx`, implementing a two‑pane source/output layout and UI chrome for model settings. 
- Added a 25‑language list and a reusable `LanguageAutocomplete` input that supports case‑insensitive type‑to‑search for both `From language` and `To language` selectors. 
- Implemented prompt construction (`buildConversionPrompt`), a demo fallback, and a model‑agnostic request flow (`requestTranslation`) that POSTs `{ sourceLanguage, targetLanguage, mode, prompt, sourceCode }` to a configurable `endpoint` with optional bearer token. 
- Added UX features including `Convert Code`, `Swap` languages, `Load sample`, `Copy` output, loading and error states, and extension modes `Standard`, `Signal`, `Cipher`, and `Echo`.

### Testing
- Ran the production build with `npm run build` in `stageport-ui` and the build completed successfully. 
- The app was smoke‑tested locally in demo mode (no endpoint configured) to verify UI flows for language selection, sample loading, swapping, conversion button behavior, and clipboard copy.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c71737d4588330a07a86a49c70bd25)