### PR TITLE
Add local-first CodeVerter PRO with true before/after evaluation delta

### DIFF
--- a/codeverter-pro/README.md
+++ b/codeverter-pro/README.md
@@ -1,0 +1,25 @@
+# CodeVerter PRO (Local-first dual-evaluation prototype)
+
+This folder provides a local Python + HTML implementation of a code translation flow with a **true before/after evaluation delta**:
+
+- `server.py` (Flask API):
+  - Evaluates source code.
+  - Translates/refactors code.
+  - Re-evaluates translated code.
+  - Logs `source_score`, `target_score`, and `delta` to a CSV ledger.
+- `index.html` (React-in-browser UI):
+  - Source/Target editor panes.
+  - Execute action.
+  - Cognitive Delta dashboard (`source score → target score`, net improvement).
+
+## Run locally
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install flask flask-cors requests
+export ANTHROPIC_API_KEY="your_key_here"
+python server.py
+```
+
+Open `index.html` in your browser and call the local API at `http://127.0.0.1:5000/api/convert`.

--- a/codeverter-pro/index.html
+++ b/codeverter-pro/index.html
@@ -1,0 +1,173 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CodeVerter PRO</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  </head>
+  <body class="bg-[#121212] text-white min-h-screen">
+    <div id="root" class="p-6"></div>
+
+    <script type="text/babel">
+      const { useState } = React;
+
+      const LANGUAGES = [
+        "JavaScript",
+        "Python",
+        "TypeScript",
+        "Java",
+        "Go",
+        "Rust",
+        "C#",
+        "C++",
+      ];
+
+      function App() {
+        const [sourceLang, setSourceLang] = useState("JavaScript");
+        const [targetLang, setTargetLang] = useState("Python");
+        const [sourceCode, setSourceCode] = useState("");
+        const [outputCode, setOutputCode] = useState("");
+        const [evaluation, setEvaluation] = useState(null);
+        const [loading, setLoading] = useState(false);
+        const [error, setError] = useState("");
+
+        const handleConvert = async () => {
+          if (!sourceCode.trim()) return;
+
+          setLoading(true);
+          setError("");
+          setOutputCode("");
+          setEvaluation(null);
+
+          try {
+            const response = await fetch("http://127.0.0.1:5000/api/convert", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                sourceLanguage: sourceLang,
+                targetLanguage: targetLang,
+                sourceCode,
+              }),
+            });
+
+            const data = await response.json();
+            if (!response.ok) {
+              throw new Error(data.error || "Translation failed");
+            }
+
+            setOutputCode(data.translated_code || "");
+            setEvaluation({
+              source: data.source_evaluation,
+              target: data.target_evaluation,
+            });
+          } catch (conversionError) {
+            setError(conversionError.message);
+          } finally {
+            setLoading(false);
+          }
+        };
+
+        const sourceScore = evaluation?.source?.score ?? 0;
+        const targetScore = evaluation?.target?.score ?? 0;
+        const delta = targetScore - sourceScore;
+
+        return (
+          <div className="max-w-7xl mx-auto space-y-6 pb-12">
+            <div className="bg-[#1e1e1e] p-6 rounded-2xl border border-[#333]">
+              <h1 className="text-3xl font-bold tracking-tight text-white">
+                CodeVerter <span className="text-blue-500">PRO</span>
+              </h1>
+              <p className="mt-2 text-gray-400">Translate and optimize architecture in a single pass.</p>
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <div className="bg-[#1e1e1e] p-5 rounded-2xl border border-[#333]">
+                <div className="flex justify-between items-center mb-4">
+                  <h2 className="font-semibold text-white">Source</h2>
+                  <select value={sourceLang} onChange={(e) => setSourceLang(e.target.value)} className="bg-[#2a2a2a] text-white border border-[#444] rounded p-1 text-sm outline-none">
+                    {LANGUAGES.map((language) => (
+                      <option key={language}>{language}</option>
+                    ))}
+                  </select>
+                </div>
+                <textarea value={sourceCode} onChange={(e) => setSourceCode(e.target.value)} placeholder="Paste legacy code here..." className="w-full h-96 p-4 bg-[#121212] text-gray-300 border border-[#333] rounded-xl outline-none text-sm"></textarea>
+                <button onClick={handleConvert} disabled={loading} className="w-full mt-4 bg-blue-600 text-white py-3 rounded-xl font-semibold hover:bg-blue-700 disabled:opacity-50">
+                  {loading ? "Analyzing & Translating..." : "Execute"}
+                </button>
+                {error && <div className="mt-3 text-red-500 text-sm">{error}</div>}
+              </div>
+
+              <div className="bg-[#1e1e1e] p-5 rounded-2xl border border-[#333]">
+                <div className="flex justify-between items-center mb-4">
+                  <h2 className="font-semibold text-white">Target Artifact</h2>
+                  <select value={targetLang} onChange={(e) => setTargetLang(e.target.value)} className="bg-[#2a2a2a] text-white border border-[#444] rounded p-1 text-sm outline-none">
+                    {LANGUAGES.map((language) => (
+                      <option key={language}>{language}</option>
+                    ))}
+                  </select>
+                </div>
+                <textarea value={outputCode} readOnly placeholder="Optimized output..." className="w-full h-96 p-4 bg-[#121212] text-emerald-400 border border-[#333] rounded-xl outline-none text-sm"></textarea>
+                <button
+                  onClick={() => navigator.clipboard.writeText(outputCode)}
+                  className="w-full mt-4 bg-[#2a2a2a] text-white py-3 rounded-xl font-semibold hover:bg-[#333]"
+                >
+                  Copy Output
+                </button>
+              </div>
+            </div>
+
+            {evaluation && (
+              <div className="bg-[#1e1e1e] p-6 rounded-2xl border border-[#333]">
+                <h2 className="text-xl font-bold text-white mb-6">Cognitive Delta</h2>
+
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+                  <div className="bg-[#121212] p-4 rounded-xl border border-[#333] text-center">
+                    <div className="text-gray-500 text-xs font-bold uppercase tracking-wider mb-2">Source Score</div>
+                    <div className="text-4xl font-bold text-red-400">{sourceScore}</div>
+                  </div>
+                  <div className="flex items-center justify-center">
+                    <div className="text-center">
+                      <div className="text-gray-500 text-xs font-bold uppercase tracking-wider mb-2">Net Improvement</div>
+                      <div className={`text-3xl font-bold ${delta >= 0 ? "text-blue-500" : "text-rose-500"}`}>
+                        {delta >= 0 ? `+${delta}` : delta}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="bg-[#121212] p-4 rounded-xl border border-[#333] text-center border-b-4 border-b-emerald-500">
+                    <div className="text-gray-500 text-xs font-bold uppercase tracking-wider mb-2">Target Score</div>
+                    <div className="text-4xl font-bold text-emerald-400">{targetScore}</div>
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                  <div>
+                    <h3 className="text-sm font-bold text-gray-400 uppercase tracking-wider mb-3">Legacy Analysis</h3>
+                    <p className="text-gray-300 text-sm leading-relaxed">{evaluation.source?.summary || "No summary available."}</p>
+                  </div>
+
+                  <div>
+                    <h3 className="text-sm font-bold text-gray-400 uppercase tracking-wider mb-3">Transformations Applied</h3>
+                    <div className="space-y-3">
+                      {(evaluation.target?.improvements_made || []).map((improvement, index) => (
+                        <div key={index} className="bg-[#121212] p-3 rounded border border-[#333] border-l-2 border-l-blue-500">
+                          <div className="text-xs text-blue-400 font-bold uppercase mb-1">{improvement.rule}</div>
+                          <div className="text-gray-300 text-sm">{improvement.action}</div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      }
+
+      ReactDOM.createRoot(document.getElementById("root")).render(<App />);
+    </script>
+  </body>
+</html>

--- a/codeverter-pro/server.py
+++ b/codeverter-pro/server.py
@@ -1,0 +1,172 @@
+import csv
+import json
+import os
+from datetime import datetime
+
+import requests
+from flask import Flask, jsonify, request
+from flask_cors import CORS
+
+app = Flask(__name__)
+CORS(app)
+
+ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
+API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
+MODEL_NAME = os.environ.get("ANTHROPIC_MODEL", "claude-3-5-sonnet-20241022")
+LEDGER_FILE = os.environ.get("CODEVERTER_LEDGER", "codeverter_pro_ledger.csv")
+
+
+def append_to_ledger(
+    source_lang: str,
+    target_lang: str,
+    source_score: int,
+    target_score: int,
+) -> None:
+    """Persist a conversion score pair for auditing ROI over time."""
+    file_exists = os.path.isfile(LEDGER_FILE)
+    delta = target_score - source_score
+
+    with open(LEDGER_FILE, mode="a", newline="", encoding="utf-8") as ledger:
+        writer = csv.writer(ledger)
+        if not file_exists:
+            writer.writerow(
+                [
+                    "timestamp",
+                    "source_lang",
+                    "target_lang",
+                    "source_score",
+                    "target_score",
+                    "delta",
+                ]
+            )
+
+        writer.writerow(
+            [
+                datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                source_lang,
+                target_lang,
+                source_score,
+                target_score,
+                f"+{delta}" if delta > 0 else str(delta),
+            ]
+        )
+
+
+def build_prompt(source_lang: str, target_lang: str, source_code: str) -> str:
+    return f"""You are an expert software engineer and strict code reviewer.
+
+Task:
+1. Evaluate the original {source_lang} code against the 7 Rules.
+2. Translate the code to {target_lang}, refactoring it to strictly adhere to the 7 Rules.
+3. Evaluate your translated {target_lang} code against the same 7 Rules.
+
+The 7 Rules:
+1. Descriptive names
+2. Function size (<200 lines, >5 lines unless public)
+3. Explicit dependencies (no hidden global state)
+4. Robust error handling (no empty try/catch)
+5. Nesting depth (max 2-3 levels)
+6. Obvious side effects
+7. No magic numbers
+
+Output ONLY valid JSON in this exact structure:
+{{
+  "source_evaluation": {{
+    "score": <int 0-100>,
+    "summary": "<main flaws in the source architecture>"
+  }},
+  "translated_code": "<the refactored {target_lang} code>",
+  "target_evaluation": {{
+    "score": <int 0-100>,
+    "improvements_made": [
+      {{
+        "rule": "<one of the 7 rules>",
+        "action": "<specific change applied>"
+      }}
+    ]
+  }}
+}}
+
+Source Code ({source_lang}):
+{source_code}
+"""
+
+
+def _extract_message_text(response_json: dict) -> str:
+    content = response_json.get("content", [])
+    if not content:
+        raise ValueError("No content returned from Anthropic.")
+
+    text_chunks = [part.get("text", "") for part in content if part.get("type") == "text"]
+    raw_text = "\n".join(chunk for chunk in text_chunks if chunk).strip()
+    if not raw_text:
+        raise ValueError("Empty text response from Anthropic.")
+    return raw_text
+
+
+def _parse_llm_json(raw_text: str) -> dict:
+    cleaned = raw_text.replace("```json", "").replace("```", "").strip()
+    result = json.loads(cleaned)
+
+    if not isinstance(result, dict):
+        raise ValueError("Unexpected model output shape.")
+
+    if "source_evaluation" not in result or "target_evaluation" not in result:
+        raise ValueError("Model response missing required evaluation fields.")
+
+    return result
+
+
+@app.post("/api/convert")
+def convert_and_evaluate():
+    payload = request.get_json(silent=True) or {}
+    source_lang = payload.get("sourceLanguage")
+    target_lang = payload.get("targetLanguage")
+    source_code = payload.get("sourceCode")
+
+    if not all([source_lang, target_lang, source_code]):
+        return jsonify({"error": "Missing required parameters."}), 400
+
+    if not API_KEY:
+        return jsonify({"error": "ANTHROPIC_API_KEY is not set."}), 500
+
+    anthropic_headers = {
+        "x-api-key": API_KEY,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+    }
+
+    anthropic_payload = {
+        "model": MODEL_NAME,
+        "max_tokens": 4000,
+        "system": "You are a code translation and evaluation engine. Output ONLY JSON.",
+        "messages": [{"role": "user", "content": build_prompt(source_lang, target_lang, source_code)}],
+    }
+
+    try:
+        response = requests.post(
+            ANTHROPIC_URL,
+            headers=anthropic_headers,
+            json=anthropic_payload,
+            timeout=90,
+        )
+        response.raise_for_status()
+
+        raw_text = _extract_message_text(response.json())
+        result_data = _parse_llm_json(raw_text)
+
+        source_score = int(result_data.get("source_evaluation", {}).get("score", 0))
+        target_score = int(result_data.get("target_evaluation", {}).get("score", 0))
+        append_to_ledger(source_lang, target_lang, source_score, target_score)
+
+        return jsonify(result_data)
+    except requests.RequestException as error:
+        return jsonify({"error": f"Anthropic request failed: {error}"}), 502
+    except (ValueError, json.JSONDecodeError) as error:
+        return jsonify({"error": f"Response parse failed: {error}"}), 500
+    except Exception as error:  # defensive boundary
+        return jsonify({"error": str(error)}), 500
+
+
+if __name__ == "__main__":
+    app.run(port=5000, debug=True)


### PR DESCRIPTION
### Motivation
- Provide a local-first, file-native prototype that translates and refactors code while quantifying architectural improvement as a before/after score delta. 
- Support an audit trail for ROI-style reporting by ledgering source/target scores and the computed delta to a CSV file. 
- Keep the stack simple and self-hostable using Python (Flask) for the orchestrator and a single-file HTML+React receptor. 

### Description
- Add `codeverter-pro/server.py`, a Flask API that builds a strict LLM prompt, calls the Anthropic endpoint, extracts and sanitizes the LLM JSON, computes `source_score` and `target_score`, and appends `(source_score, target_score, delta)` to a CSV ledger. 
- Add `codeverter-pro/index.html`, a small React-in-browser UI that posts to `/api/convert`, renders source/target editors, and displays a Cognitive Delta dashboard with Source Score, Target Score, Net Improvement, legacy summary, and applied transformation list. 
- Add `codeverter-pro/README.md` with local run instructions and environment variable usage (`ANTHROPIC_API_KEY`, `ANTHROPIC_MODEL`, `CODEVERTER_LEDGER`). 
- Implement defensive parsing and error paths in the backend (response text extraction, JSON cleanup, explicit request/parse exception handling) and include defaults for model and ledger file names. 

### Testing
- Compiled the new Python backend with `python -m py_compile codeverter-pro/server.py` which succeeded. 
- Also ran `python -m py_compile day_sheet_writer.py` as a sanity compile check and it succeeded. 
- No automated integration tests run against the live Anthropic call in this rollout; the server includes explicit error handling for request and parse failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c71f08f5e483309a04fff70a2c385c)