### PR TITLE
Add generic Phase I–III automation governance playbook

### DIFF
--- a/docs/automation_governance_install_playbook.md
+++ b/docs/automation_governance_install_playbook.md
@@ -1,0 +1,207 @@
+# Automation Governance Install Playbook (Generic CLIENT Edition)
+
+## Purpose
+This playbook converts a branded Phase I offer into a **generic, repeatable, premium service system** that is easy to sell, easy to deliver, and easy to scale for founder-led companies.
+
+It is intentionally written in **non-technical founder language** while preserving operational rigor.
+
+---
+
+## 1) Suggestion Categories Table
+
+Use this table for recommendations, roadmap items, and meeting follow-ups.
+
+| Category | Definition | Typical Examples | Buyer Value Signal | Owner |
+|---|---|---|---|---|
+| Revenue Lift | Changes that accelerate top-line growth | Offer funnel fixes, conversion sequence, lead routing automation | “This pays for itself quickly” | Growth Lead |
+| Risk Control | Changes that reduce legal, data, or reputational risk | Permission controls, audit trails, policy automation | “Safer to scale and fundraise” | Ops + Legal |
+| Capacity Gain | Changes that reclaim founder/team time | Delegation workflows, task orchestration, approval layers | “More output without hiring too early” | COO / Chief of Staff |
+| Decision Clarity | Changes that improve visibility and governance | KPI dashboards, escalation paths, weekly governance rhythm | “CEO control with less chaos” | Founder + Ops |
+| Brand/Investor Readiness | Changes that increase confidence with partners and investors | Reporting packet, operating cadences, maturity map | “Looks institutional, not improvised” | Founder + Finance |
+| Platform Readiness | Changes that set up Phase II/III technical scale | Data model hygiene, API boundaries, integration roadmap | “No expensive rebuild later” | Technical Lead |
+
+---
+
+## 2) Priority Level Definitions
+
+| Priority | Meaning | Time Horizon | Selection Rule |
+|---|---|---|---|
+| P0 — Critical Now | Blocker, compliance risk, or immediate revenue loss | 0–14 days | Do first, no debate |
+| P1 — High Leverage | Strong ROI and unlocks multiple next steps | 2–6 weeks | Do in current phase |
+| P2 — Strategic Build | Important but not urgent; compounds over time | 1–3 months | Queue behind P0/P1 |
+| P3 — Optional Upgrade | Nice-to-have polish or speculative bet | 3+ months | Only after core engine is stable |
+
+**Scoring quick rule:** prioritize items with highest combination of **Impact × Confidence ÷ Effort**.
+
+---
+
+## 3) Guidelines for Both Modes
+
+This offer should run in two delivery modes.
+
+### Mode A: Build Mode (execution)
+- Objective: stand up founder-safe automation governance infrastructure.
+- Cadence: weekly build sprint + weekly executive checkpoint.
+- Output style: decisions, SOP artifacts, automation flows, and visible wins.
+- Success test: founder can delegate safely without losing strategic control.
+
+### Mode B: Closeout & Expansion Mode (commercial)
+- Objective: prove value, narrate wins, and convert naturally into Phase II.
+- Cadence: 30-minute closeout + written expansion map within 24 hours.
+- Output style: before/after metrics, maturity score, and tiered upgrade menu.
+- Success test: client sees Phase II as the logical next step, not a hard sell.
+
+---
+
+## 4) Phase I at **$7,500** — What It Actually Buys
+
+## Deliverable promise
+A full **Automation Governance Install** that gives founders:
+1. Control (clear decision rights)
+2. Capacity (less founder bottleneck)
+3. Credibility (investor/partner-ready operating system)
+
+### Scope included (end-to-end)
+1. **Founder Operating Diagnostic**
+   - workflow map, risk map, bottleneck map
+   - current-state baseline and maturity scoring
+
+2. **Governance Architecture Setup**
+   - decision ladder (what requires founder approval vs delegated authority)
+   - escalation matrix and ownership map
+   - weekly governance rhythm (agenda, KPIs, review protocol)
+
+3. **Core Automation Install (Phase I level)**
+   - 3–5 priority automations (intake, triage, approvals, reporting, handoff)
+   - standardized forms/templates and approval logic
+   - notification routing and accountability tracking
+
+4. **Risk + Compliance Guardrails (lightweight but real)**
+   - policy baseline for data handling and access
+   - simple audit trail structure
+   - change-control checkpoints
+
+5. **Founder Enablement & Team Adoption**
+   - role-specific playbooks
+   - onboarding/training session(s)
+   - handoff documentation and “day 1 to day 30” support map
+
+6. **Closeout + Expansion Blueprint**
+   - quantified outcomes from Phase I
+   - Phase II options with timeline and budget
+   - executive narrative for board/investor conversations
+
+### Why $7,500 is fair and market-valid (NY)
+- Comparable NYC governance + automation strategy engagements often price in the low five figures once custom process design and implementation are included.
+- A productized $7,500 entry point is strong value for founders because it combines strategy, implementation, and transition support in one cycle.
+- It avoids the hidden cost pattern of cheap diagnostics followed by fragmented hourly work.
+
+### “Why this works” in founder language
+- You are not paying for tools; you are paying to remove chaos tax.
+- You are buying an operating structure that lets you act like a CEO, not a dispatcher.
+- You are converting repeated decisions into governed systems so growth does not break operations.
+
+---
+
+## 5) 30-Minute End-of-Phase-I Closeout (Upsell Strategy)
+
+## Meeting objective
+Create an undeniable bridge from **results achieved** to **next strategic ceiling**.
+
+### Agenda (30 minutes)
+1. **0:00–5:00 — Executive recap**
+   - “What changed” in plain outcomes (speed, visibility, risk reduction)
+2. **5:00–12:00 — Before/after scorecard**
+   - baseline vs now (cycle time, founder interrupts, response consistency)
+3. **12:00–20:00 — Constraint reveal**
+   - identify what Phase I intentionally did *not* solve
+   - show risk/revenue opportunity if left unaddressed
+4. **20:00–27:00 — Phase II pathway**
+   - present 3 tier options with timeline and commercial logic
+5. **27:00–30:00 — Decision capture**
+   - choose tier or schedule scoping workshop within 7 days
+
+### Closeout script architecture
+- Celebrate capability built (“you now have institutional control”).
+- Name the next bottleneck (“volume will now expose integration limits”).
+- Reframe investment as momentum protection (“Phase II protects gains already purchased”).
+
+---
+
+## 6) Professional Tier Map (Phase II → Phase III)
+
+## Phase II (Commercial Scale Layer)
+
+| Tier | Best Fit | Timeline (solo-firm realistic) | NYC Price Range | What Founder Gets |
+|---|---|---|---|---|
+| Tier 1: Foundation Scale | Early traction teams needing stronger execution | 4–6 weeks | $15,000–$30,000 | More delegation, cleaner handoffs, founder calendar reclaimed |
+| Tier 2: Growth Ops Engine | Revenue-moving teams with cross-functional friction | 8–12 weeks | $35,000–$75,000 | End-to-end operating rhythm, reporting confidence, predictable execution |
+| Tier 3: Institutional Readiness | Teams preparing for aggressive growth/fundraise/partnership complexity | 12–20 weeks | $85,000–$180,000 | Board/investor-grade operating governance and multi-team orchestration |
+
+## Phase III (Advanced Intelligence & Adaptive Governance)
+
+| Tier | Best Fit | Timeline | NYC Price Range | What Founder Gets |
+|---|---|---|---|---|
+| Tier 3A: Decision Intelligence | Wants predictive visibility before problems surface | +8–12 weeks | $75,000–$150,000 | Early-warning insights and smarter executive prioritization |
+| Tier 3B: Adaptive Governance Fabric | Complex org/environment with rapid change | +12–24 weeks | $150,000–$350,000+ | Dynamic governance with strategic control at scale |
+
+**Maintenance model:** typically 15–25% annual support based on stack complexity and SLA expectations.
+
+---
+
+## 7) Non-Technical Price Menu Language (Founder-Friendly)
+
+Use the following commercial framing:
+
+- **“Starter Control Layer”** (Tier 1)
+  - You stop being the single point of failure.
+- **“Growth Command Layer”** (Tier 2)
+  - You gain a predictable operating machine your team can run without constant founder intervention.
+- **“Institutional Power Layer”** (Tier 3)
+  - You operate with the confidence and structure expected of category-leading CEOs.
+
+Keep language aspirational but truthful: prestige comes from systems that deliver consistent outcomes.
+
+---
+
+## 8) Automation Flow Architecture (Generic Package)
+
+## Core process flow
+1. Intake capture → 2) Triage logic → 3) Ownership assignment → 4) Approval path → 5) Execution tracking → 6) KPI rollup → 7) Weekly governance review → 8) Exception escalation
+
+## Productized assets to standardize delivery
+- Diagnostic checklist
+- Governance charter template
+- Delegation matrix template
+- Priority scoring grid (P0–P3)
+- Automation blueprint templates by use case
+- Weekly governance deck template
+- Closeout scorecard + Phase II proposal template
+
+These assets create a bespoke client experience while preserving repeatable delivery economics.
+
+---
+
+## 9) Fair Compensation Menu (Simple, Scalable)
+
+| Offer Component | Pricing Logic | Typical Price |
+|---|---|---|
+| Phase I Install | Fixed-fee productized engagement | $7,500 |
+| Phase II Build | Tiered project fee by complexity | $15,000–$180,000 |
+| Phase III Layer | Advanced architecture + intelligence modules | $75,000–$350,000+ |
+| Retainer / Stewardship | Ongoing governance + optimization | $2,500–$12,500/month |
+| Add-ons | Scoped micro-projects | Quoted per module |
+
+Compensation remains fair when outcomes are measurable, decision rights are clear, and operational burden is visibly reduced.
+
+---
+
+## 10) Packaging Notes for “Likely to Sell and Scale”
+
+- Keep Phase I fixed-fee and outcome-focused.
+- Use a **single-page scorecard** to show value rapidly.
+- Make Phase II options visible from day one (without pressure).
+- Standardize 80% of delivery; customize 20% for founder context.
+- Tie every upsell point to risk reduction, speed gain, or authority expansion.
+
+This is how a premium governance offer feels personal to the founder while still operating like a scalable professional system.


### PR DESCRIPTION
### Motivation
- Remove brand-specific SYVAQ framing and produce a reusable, client-facing Phase I–III automation governance offer. 
- Provide a market-ready, productized Phase I that is easy to sell, deliver, and scale for founder-led teams with founder-friendly language and clear upsell pathways. 
- Standardize pricing bands and tiered Phase II/III options so delivery and commercial conversations are repeatable and investor-friendly.

### Description
- Adds `docs/automation_governance_install_playbook.md`, a 200+ line playbook that replaces branded content with a generic "CLIENT" edition and productized delivery guidance. 
- The playbook includes a suggestion categories table, P0–P3 priority definitions, dual delivery modes (Build vs Closeout/Expansion), and a detailed Phase I scope priced at $7,500. 
- Adds a 30-minute closeout/upsell agenda, realistic NYC Phase II/III tier maps with timelines and price bands, non-technical commercial language, productized assets, and a fair compensation menu. 
- Commit created on branch `work` and file staged as `docs/automation_governance_install_playbook.md` in the repo.

### Testing
- Inspected the new file with `nl -ba docs/automation_governance_install_playbook.md` to verify content, which succeeded. 
- Verified repository status with `git status --short` and recorded HEAD with `git rev-parse --short HEAD`, which succeeded and produced commit `46b3c77`. 
- Committed the file using `git add` + `git commit -m "Add generic automation governance install playbook with pricing tiers"`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c7bc43d974833096fce9da3ff4606c)