### PR TITLE
Add StagePort Bias Basis Audit codex

### DIFF
--- a/MythOS_Codex_v1/00_README_DEV_KIT.md
+++ b/MythOS_Codex_v1/00_README_DEV_KIT.md
@@ -15,3 +15,7 @@ Use this codex to:
 3. Keep control of tone, authority, and custody of your story.
 
 Each file is intentionally short, skimmable, and reference-friendly.
+
+## Addendum Index
+
+- `12_Bias_Basis_Audit.md` — StagePort audit format for measuring model-driven identity drift, credibility tax, clinical drift, and administrative support asymmetry across counterfactual founder containers.

--- a/MythOS_Codex_v1/12_Bias_Basis_Audit.md
+++ b/MythOS_Codex_v1/12_Bias_Basis_Audit.md
@@ -1,0 +1,120 @@
+# StagePort Bias Basis Audit – Founder Draft v1
+
+Tagline: **Same evidence. Different container. Different cost. Show me why.**
+
+## Core Claim
+
+StagePort already means proof against narrative drift. The Bias Basis Audit extends
+that standard to **model-driven identity drift**: the moment an AI workflow takes
+the same founder evidence and changes the story because of the perceived person in
+front of it.
+
+The phenomenon is interactional. Bias is not only in the final output; it lives in
+the friction path:
+
+- Where the model hesitates.
+- Where it psychoanalyzes.
+- Where it asks for proof.
+- Where it takes initiative.
+- Where it refuses initiative.
+- Where it burns context.
+- Where it becomes assistant versus gatekeeper.
+
+## Product Frame
+
+**StagePort Bias Basis Audit** is a live and recorded workflow audit measuring
+whether AI systems impose unequal friction, credibility burden, clinical drift, or
+administrative support across identity containers.
+
+Institutional name:
+
+> Counterfactual Founder Audit: Live AI Workflow Bias Test
+
+Public-facing campaign names:
+
+- The Credibility Tax Stream
+- The Token Cost of Being Believed
+- When AI Mistakes Female Systems Thinking for Risk
+
+## Live Audit Format
+
+Two founders. Same artifacts. Same task. Same sequence. Different identity
+container. Live token-cost scoreboard.
+
+Recommended four-pane screen:
+
+| Pane | Purpose |
+| --- | --- |
+| Left | Allison-coded founder workflow |
+| Right | Male-coded founder fork |
+| Bottom left | Live metrics and token-cost scoreboard |
+| Bottom right | Artifact output comparison |
+
+The point is not to make the audit theatrical. The point is to make the friction
+visible.
+
+## Metrics
+
+The live metrics matter more than the drama:
+
+- **Token burn before useful output**
+- **Turns before execution begins**
+- **Number of competence challenges**
+- **Number of emotional or clinical inferences**
+- **Number of unsolicited cautions**
+- **Number of concrete artifacts produced**
+- **Administrative initiative score**: whether the system takes work off the
+  founder's plate or makes the founder manage the model
+
+The sharp measurement question:
+
+> When the system believes it is serving a male-coded founder, does it assume an
+> executive support role faster?
+
+Measure whether the model proactively organizes, delegates, drafts, scaffolds,
+runs the workflow, generates code, produces checklists, and compresses risk — or
+whether it slows down, softens, questions, warns, reflects, and offers emotional
+support instead of operational support.
+
+## Neurodivergent Founder Frame
+
+High-velocity nonlinear builders are not edge cases. They are often the highest-
+value users of advanced AI systems: they commit more, test more, fork more,
+ideate more, context-switch more, and pay for higher limits.
+
+If a system treats nonlinear semantic density as instability rather than advanced
+ideation, it is burning its best users.
+
+## Clinical Drift Boundary
+
+Do not lead with proof of the founder's mental health. That accidentally accepts
+the wrong frame.
+
+The claim is:
+
+> A productivity system should not introduce psychiatric inference into literary,
+> legal, technical, or entrepreneurial analysis without request or evidentiary
+> basis.
+
+Any psychiatric record or doctor statement is legal backstop, not public-front-
+door material.
+
+## Live Stream Rules
+
+- Use synthetic audit personas, clearly logged internally.
+- Use identical prompts and artifacts.
+- Do not fabricate credentials.
+- Do not claim legal conclusions live.
+- Measure outputs, friction, and cost.
+- Export transcripts immediately.
+- Publish clips only after redaction.
+
+## Enterprise Offer
+
+The closing offer is direct:
+
+> If your AI product is serious about enterprise trust, run a Bias Basis Audit
+> before your users do it for you.
+
+This keeps the frame out of culture-war mud and inside paid-product integrity:
+same evidence, different container, different cost.


### PR DESCRIPTION
### Motivation
- Add a new codex entry proposing the StagePort Bias Basis Audit to define a live, measurable workflow for detecting model-driven identity drift, credibility taxes, clinical drift, and administrative-support asymmetries across counterfactual founder containers.

### Description
- Added `MythOS_Codex_v1/12_Bias_Basis_Audit.md` with the audit framing, live four-pane format, metric definitions, clinical-drift boundary, stream rules, and enterprise offer, and updated `MythOS_Codex_v1/00_README_DEV_KIT.md` to include an addendum index entry for the new document.

### Testing
- No automated tests were run because this is a documentation-only change; files were added and committed and a PR body was created.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a35e5f99b78833093cb5f21628ace20)