### PR TITLE
Add Founderfeit audit module to StagePort MVP brief

### DIFF
--- a/stageport_stack/80_docs/stageport_mvp_modules.md
+++ b/stageport_stack/80_docs/stageport_mvp_modules.md
@@ -40,6 +40,17 @@ This brief converts the existing StagePort memnode and product specs into a prac
 - **Outputs:** Role assignments, IX-friendly change log, receipts bundle for legal/archive.
 - **Infra hooks:** Keep FSM and risk weights server-side; ship only signed decisions to clients. Maintain per-surface node schema for HOME/CALLBOARD rollups.
 
+### Founderfeit Audit (persona + credibility drift)
+- **Product names:** Token Counterfeit for the cost-layer workflow audit; Founderfeit for the persona/audit layer.
+- **Inputs:** Company artifacts, controlled founder identity containers, evidence packets, task prompts, execution traces, and token-level transcripts.
+- **Processing:** Run identical proof bundles through controlled founder profiles to detect model-driven narrative drift, unnecessary credibility checks, clinical drift, semantic friction, biased hesitation, unequal administrative initiative, and delayed execution.
+- **Outputs:** Founderfeit differential report, credibility-tax score, token-burn breakdown, administrative-initiative score, narrative-drift findings, and remediation notes for prompt routing or workflow policy.
+- **Core metric:** `Credibility Tax = Tokens spent before execution / Total tokens spent`.
+- **Secondary metric:** `Administrative Initiative = Useful autonomous work produced before the user has to re-explain, defend, or manage the model`.
+- **Taglines:** "Same proof. Different founder. Different cost." and "When the founder changes, does the work change?"
+- **Live stream title:** "Token Counterfeit: The Cost of Being Believed by AI".
+- **Infra hooks:** Store founder containers separately from company evidence; hash prompt/evidence bundles so audits compare identical proof across identity variants. Keep persona labels pseudonymous in exports unless the operator explicitly approves disclosure. Use synthetic audit personas only; do not fabricate real credentials, employment history, contracts, medical claims, or legal status.
+
 ## Implementation Steps (MVP)
 1. **Wire node schemas:** Apply the StagePort node schema to HOME and CALLBOARD to define inputs/outputs, owners, and safety grades for the first release.
 2. **Data minimization pass:** Implement pipelines that drop raw capture media after feature extraction; retain only derived metrics and IX audit hashes.


### PR DESCRIPTION
### Motivation
- Formalize a persona-focused audit module in the StagePort MVP so credibility drift is treated as an infra-grade audit rather than a side rant. 
- Reframe the language to separate cost-layer audits and persona/audit layer naming to reduce legal heat by using `Token Counterfeit` for cost-layer and `Founderfeit` for persona/audit. 
- Capture measurable, evidence-backed metrics (including administrative initiative) and add an explicit non-deception constraint for audit personas.

### Description
- Added a new `### Founderfeit Audit (persona + credibility drift)` section to `stageport_stack/80_docs/stageport_mvp_modules.md` following the existing Inputs → Processing → Outputs → Infra hooks pattern. 
- Introduced product names `Token Counterfeit` (cost-layer) and `Founderfeit` (persona/audit) and listed `Inputs`, `Processing`, and `Outputs` for controlled audits. 
- Added core and secondary metrics including `Credibility Tax = Tokens spent before execution / Total tokens spent` and `Administrative Initiative = Useful autonomous work produced before the user has to re-explain, defend, or manage the model`. 
- Added infra guidance to store founder containers separately, hash prompt/evidence bundles for identical-proof comparisons, keep persona labels pseudonymous by default, and require synthetic audit personas only with an explicit prohibition on fabricating real credentials, employment history, contracts, medical claims, or legal status. 

### Testing
- Ran `git diff --check` on the working tree and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a35e820620c8330a736f7ad2a083128)