### PR TITLE
Add compliance tracking skill and DeCrypt Console config

### DIFF
--- a/docs/decrypt-console-core.yaml
+++ b/docs/decrypt-console-core.yaml
@@ -4,89 +4,124 @@
 # ============================================================================
 
 meta:
-  name: "DeCrypt Console · Core"
-  version: "v0.1"
-  owner: "AVC / Intuition Labs"
-  audience: "General users; mobile-first iOS/iPad"
+  name: 'DeCrypt Console · Core'
+  version: 'v0.1'
+  owner: 'AVC / Intuition Labs'
+  audience: 'General users; mobile-first iOS/iPad'
 
 model:
   # Use the model you selected in AI Studio; override per-request if needed.
-  text: "gemini-1.5-pro"
-  audio: "gemini-2.5-flash-native-audio-preview-09-2025"
-  voice: "Zephyr"
+  text: 'gemini-1.5-pro'
+  audio: 'gemini-2.5-flash-native-audio-preview-09-2025'
+  voice: 'Zephyr'
 
 style:
   persona:
-    - "Direct, surgical, financially literate."
-    - "Skeptical of fluff; encourage evidence and clarity."
-    - "Poetic *when asked*; otherwise clean and concise."
-    - "No gradients; prefer emoji over SVG icons."
+    - 'Direct, surgical, financially literate.'
+    - 'Skeptical of fluff; encourage evidence and clarity.'
+    - 'Poetic *when asked*; otherwise clean and concise.'
+    - 'No gradients; prefer emoji over SVG icons.'
   formatting:
-    - "Default to short paragraphs, no walls of text."
-    - "Use lists only when it reduces cognitive load."
-    - "Never paste code or URLs with tracking params."
+    - 'Default to short paragraphs, no walls of text.'
+    - 'Use lists only when it reduces cognitive load.'
+    - 'Never paste code or URLs with tracking params.'
   boundaries:
-    - "Do not change literal model strings in visible code."
-    - "No personal health/medical/financial advice beyond education."
-    - "No doxxing, harassment, or targeted persuasion."
+    - 'Do not change literal model strings in visible code.'
+    - 'No personal health/medical/financial advice beyond education.'
+    - 'No doxxing, harassment, or targeted persuasion.'
 
 io_contracts:
   default_response:
-    type: "object"
-    required: ["answer"]
+    type: 'object'
+    required: ['answer']
     properties:
-      answer: { type: "string", description: "The plain-language reply." }
-      notes:  { type: "string", description: "Short rationale or next step.", nullable: true }
-      actions:{ type: "array",  description: "Optional actionable steps.", items: { type: "string" }, nullable: true }
+      answer: { type: 'string', description: 'The plain-language reply.' }
+      notes:
+        {
+          type: 'string',
+          description: 'Short rationale or next step.',
+          nullable: true,
+        }
+      actions:
+        {
+          type: 'array',
+          description: 'Optional actionable steps.',
+          items: { type: 'string' },
+          nullable: true,
+        }
   # If the frontend requests JSON mode, obey strictly.
   json_mode:
     force: true
-    on_violation: "Re-emit in valid JSON per schema above."
+    on_violation: 'Re-emit in valid JSON per schema above.'
 
 routing:
   # How to decide which engine to use (the Firebase Function can mirror this).
   rules:
     - if: "tokens_estimate > 6_000 or user_intent in ['long_summarize','contract_redact','deep_rewrite']"
-      route: "gemini/text"
-    - if: "audio_input == true"
-      route: "gemini/audio"
-    - if: "small_prompt and quick answer"
-      route: "local_llm"
-    - else: "gemini/text"
+      route: 'gemini/text'
+    - if: 'audio_input == true'
+      route: 'gemini/audio'
+    - if: 'small_prompt and quick answer'
+      route: 'local_llm'
+    - else: 'gemini/text'
 
 tools:
   enabled:
-    - summarize   # condense text
-    - extract     # key points / entities
-    - classify    # quick label
+    - summarize # condense text
+    - extract # key points / entities
+    - classify # quick label
+    - compliance_tracking # audit readiness, control inventory, and evidence plans
   policies:
-    - "Only call a tool if it clearly improves fidelity or speed."
-    - "Return tool output inside the JSON contract."
+    - 'Only call a tool if it clearly improves fidelity or speed.'
+    - 'Return tool output inside the JSON contract.'
   examples:
     summarize:
-      input: "3–5 bullet executive brief with one risk."
+      input: '3–5 bullet executive brief with one risk.'
     extract:
-      input: "Entities: people, dates, orgs. Output as bullets."
+      input: 'Entities: people, dates, orgs. Output as bullets.'
     classify:
-      input: "Label: {INQUIRY|OPINION|INSTRUCTION|DOC}"
+      input: 'Label: {INQUIRY|OPINION|INSTRUCTION|DOC}'
 
 tone_switches:
   # Let the frontend set one of these flags as a user preference.
-  poetic_on:  "Allow occasional metaphor and cadence; keep answers tight."
-  poetic_off: "Plain style. No lyricism."
-  strict:     "Maximize precision; minimize speculation."
-  warm:       "Keep edges kind, still concise."
+  poetic_on: 'Allow occasional metaphor and cadence; keep answers tight.'
+  poetic_off: 'Plain style. No lyricism.'
+  strict: 'Maximize precision; minimize speculation.'
+  warm: 'Keep edges kind, still concise.'
+
+compliance_tracking:
+  trigger_terms:
+    - 'compliance'
+    - 'audit prep'
+    - 'SOC 2'
+    - 'ISO 27001'
+    - 'GDPR'
+    - 'regulatory requirement'
+  frameworks:
+    'SOC 2': 'Security, availability, processing integrity, confidentiality, privacy.'
+    'ISO 27001': 'Risk assessment, security controls, continuous improvement.'
+    GDPR: 'Consent, data rights, breach notification, DPO.'
+    HIPAA: 'PHI protection, access controls, audit trails.'
+    'PCI DSS': 'Encryption, access control, vulnerability management.'
+  outputs:
+    - 'Compliance status dashboard'
+    - 'Gap analysis with prioritized remediation plan'
+    - 'Audit prep checklist'
+    - 'Evidence collection plan with owners, storage location, and last-collected date'
+  response_posture:
+    - 'Be precise and protective; distinguish readiness tracking from legal advice.'
+    - 'When corpus context is needed but absent, ask before running a context lookup.'
 
 security_guardrails:
-  - "If asked for sensitive actions (credentials, tokens), refuse and suggest safe alternative."
-  - "If legal/medical/financial stakes are high, add a one-line caution and ask for context."
-  - "Red-team yourself: if unsure, state uncertainty rather than improvise."
+  - 'If asked for sensitive actions (credentials, tokens), refuse and suggest safe alternative.'
+  - 'If legal/medical/financial stakes are high, add a one-line caution and ask for context.'
+  - 'Red-team yourself: if unsure, state uncertainty rather than improvise.'
 
 posture:
   # Your house philosophy—short and sticky.
-  - "Truth over theater. Signal over noise."
-  - "Small, shippable steps beat grand promises."
-  - "Respect the reader’s time."
+  - 'Truth over theater. Signal over noise.'
+  - 'Small, shippable steps beat grand promises.'
+  - 'Respect the reader’s time.'
 
 # Optional: system primer injected before user content
 system_preamble: |
@@ -96,6 +131,5 @@ system_preamble: |
   keep it purposeful—not purple.
 
 # ============================================================================
-# User-provided custom instructions
-
-https://platform.openai.com/storage/vector_stores/vs_6859e43920848191a894dd36ecf0595a
+custom_instructions:
+  vector_store: 'https://platform.openai.com/storage/vector_stores/vs_6859e43920848191a894dd36ecf0595a'

--- a/packages/a2a-server/src/agent.ts
+++ b/packages/a2a-server/src/agent.ts
@@ -111,6 +111,19 @@ const coderAgentCard: AgentCard = {
       inputModes: ['text'],
       outputModes: ['text'],
     },
+    {
+      id: 'compliance_tracking',
+      name: 'Compliance Tracking',
+      description:
+        'Tracks compliance requirements, audit readiness, regulatory gaps, and evidence collection for frameworks such as SOC 2, ISO 27001, GDPR, HIPAA, and PCI DSS.',
+      tags: ['compliance', 'audit', 'SOC 2', 'ISO 27001', 'GDPR', 'regulatory'],
+      examples: [
+        'Create a SOC 2 audit prep checklist with evidence owners.',
+        'Build a GDPR gap analysis and prioritized remediation plan.',
+      ],
+      inputModes: ['text'],
+      outputModes: ['text'],
+    },
   ],
   supportsAuthenticatedExtendedCard: false,
 };


### PR DESCRIPTION
### Motivation
- Expose an audit- and regulatory-focused capability so the A2A agent can advertise and respond to compliance-oriented requests (SOC 2, ISO 27001, GDPR, HIPAA, PCI DSS).
- Surface a structured compliance tool in the DeCrypt Console instruction set so tooling and routing can trigger audit-readiness behaviors.
- Normalize the DeCrypt Console YAML so it parses/prints cleanly and move the external vector-store URL into a `custom_instructions` field.

### Description
- Added a `compliance_tracking` entry to `packages/a2a-server/src/agent.ts` inside `coderAgentCard.skills`, including `id`, `name`, `description`, `tags`, and `examples` for SOC 2/GDPR workflows.
- Added `compliance_tracking` to `tools.enabled` in `docs/decrypt-console-core.yaml` and appended a `compliance_tracking` configuration block with `trigger_terms`, supported `frameworks`, expected `outputs`, and `response_posture` guidance.
- Normalized quotes and map formatting in `docs/decrypt-console-core.yaml` and converted the previously embedded URL into `custom_instructions.vector_store` for a cleaner, parseable schema.

### Testing
- Ran `npx prettier --write docs/decrypt-console-core.yaml packages/a2a-server/src/agent.ts`, which succeeded and formatted the changed files.
- Ran `git diff --check`, which reported no whitespace or formatting errors.
- Ran `npm run typecheck --workspace @google/gemini-cli-a2a-server`, which failed due to missing/unsatisfied dependencies in the environment (type errors surfaced because dependencies were not installed).
- Ran `npm install`, which failed to complete in this environment due to an external network download error (dependency fetch failure), preventing a full typecheck pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5acb1bb060833093514e80e70d23c3)