### PR TITLE
Add Founder Agent prototype page and link from public index

### DIFF
--- a/public/founder-agent/index.html
+++ b/public/founder-agent/index.html
@@ -1,0 +1,392 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Founder Agent — Global AVC Systems</title>
+<style>
+  :root{
+    --bg:#0b0b14;
+    --panel:#12121f;
+    --panel-2:#171728;
+    --violet:#6d28d9;
+    --violet-2:#4c1d95;
+    --gold:#e8c468;
+    --teal:#2dd4bf;
+    --rose:#e8617a;
+    --text:#f2efe6;
+    --muted:#9b98ad;
+    --line:#2a2a3d;
+    --mono: 'SF Mono', 'Roboto Mono', Consolas, monospace;
+    --sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+  }
+  *{box-sizing:border-box;}
+  body{
+    margin:0; background:var(--bg); color:var(--text); font-family:var(--sans);
+    min-height:100vh;
+  }
+  .bg-orb{
+    position:fixed; border-radius:50%; filter:blur(2px); opacity:.35; z-index:0; pointer-events:none;
+  }
+  .orb1{width:420px;height:420px; background:var(--violet-2); top:-160px; right:-140px;}
+  .orb2{width:260px;height:260px; background:var(--violet); top:20px; right:60px; opacity:.5;}
+  .orb3{width:320px;height:320px; background:var(--gold); opacity:.12; bottom:-140px; left:-120px;}
+
+  .shell{position:relative; z-index:1; max-width:880px; margin:0 auto; padding:28px 20px 60px;}
+
+  header{display:flex; justify-content:space-between; align-items:baseline; border-bottom:1px solid var(--line); padding-bottom:14px; margin-bottom:18px;}
+  header .brand{font-weight:700; letter-spacing:.04em; font-size:13px; text-transform:uppercase; color:var(--gold);}
+  header .sub{font-size:11px; color:var(--muted); text-transform:uppercase; letter-spacing:.08em;}
+
+  h1{font-size:26px; margin:6px 0 4px; letter-spacing:-.01em;}
+  .tagline{color:var(--muted); font-size:14px; margin:0 0 22px; max-width:520px;}
+
+  .tabs{display:flex; gap:8px; margin-bottom:18px; flex-wrap:wrap;}
+  .tab{
+    border:1px solid var(--line); background:var(--panel); color:var(--muted);
+    padding:8px 14px; border-radius:999px; font-size:12.5px; cursor:pointer;
+    font-weight:600; letter-spacing:.02em; transition:.15s;
+  }
+  .tab.active{color:var(--bg); border-color:transparent;}
+  .tab[data-tier="public"].active{background:var(--teal);}
+  .tab[data-tier="investor"].active{background:var(--gold);}
+  .tab[data-tier="partner"].active{background:var(--violet); color:#fff;}
+  .tab[data-tier="inbox"].active{background:var(--rose); color:#fff;}
+
+  .panel{background:var(--panel); border:1px solid var(--line); border-radius:16px; padding:0; overflow:hidden;}
+
+  .tierbar{display:flex; justify-content:space-between; align-items:center; padding:14px 18px; border-bottom:1px solid var(--line); background:var(--panel-2);}
+  .tierbar .name{font-weight:700; font-size:14px;}
+  .tierbar .desc{font-size:12px; color:var(--muted); margin-top:2px;}
+  .dot{width:8px;height:8px;border-radius:50%; display:inline-block; margin-right:6px;}
+
+  .chat{height:420px; overflow-y:auto; padding:18px; display:flex; flex-direction:column; gap:14px;}
+  .msg{max-width:82%; padding:11px 14px; border-radius:12px; font-size:14px; line-height:1.5;}
+  .msg.user{align-self:flex-end; background:var(--violet); color:#fff; border-bottom-right-radius:3px;}
+  .msg.agent{align-self:flex-start; background:var(--panel-2); border:1px solid var(--line); border-bottom-left-radius:3px;}
+  .msg.hold{align-self:flex-start; background:#241a13; border:1px solid #5c4322; color:#f0d9a8;}
+  .receipt{display:inline-block; margin-top:8px; font-family:var(--mono); font-size:10.5px; color:var(--muted); letter-spacing:.02em;}
+
+  .composer{display:flex; gap:10px; padding:14px 18px; border-top:1px solid var(--line); background:var(--panel-2);}
+  textarea{flex:1; resize:none; background:var(--bg); color:var(--text); border:1px solid var(--line); border-radius:10px; padding:10px 12px; font-family:var(--sans); font-size:14px; height:44px;}
+  textarea:focus{outline:2px solid var(--gold); outline-offset:1px;}
+  button.send{background:var(--gold); color:#1a1508; border:none; border-radius:10px; padding:0 18px; font-weight:700; cursor:pointer; font-size:13px;}
+  button.send:disabled{opacity:.5; cursor:default;}
+  button.send:focus-visible{outline:2px solid #fff;}
+
+  .intake{padding:18px; display:grid; gap:10px; grid-template-columns:1fr 1fr; border-bottom:1px solid var(--line); background:var(--panel-2);}
+  .intake label{font-size:11px; color:var(--muted); text-transform:uppercase; letter-spacing:.05em; display:block; margin-bottom:4px;}
+  .intake input, .intake select{width:100%; background:var(--bg); border:1px solid var(--line); color:var(--text); border-radius:8px; padding:8px 10px; font-size:13px;}
+  .intake .full{grid-column:1/-1;}
+
+  .inbox-list{padding:18px; display:flex; flex-direction:column; gap:12px; max-height:520px; overflow-y:auto;}
+  .inbox-item{border:1px solid var(--line); background:var(--panel-2); border-radius:10px; padding:14px;}
+  .inbox-item .meta{display:flex; justify-content:space-between; font-size:11px; color:var(--muted); margin-bottom:8px; font-family:var(--mono);}
+  .inbox-item .q{font-size:13.5px; margin-bottom:6px;}
+  .inbox-item .reason{font-size:12px; color:var(--gold);}
+  .empty{padding:40px 18px; text-align:center; color:var(--muted); font-size:13px;}
+  .gate{padding:40px 18px; text-align:center;}
+  .gate input{background:var(--bg); border:1px solid var(--line); color:var(--text); padding:8px 12px; border-radius:8px; margin-top:10px;}
+  .gate button{margin-left:8px; background:var(--rose); color:#fff; border:none; border-radius:8px; padding:8px 14px; font-weight:700; cursor:pointer;}
+
+  .foot{margin-top:16px; font-size:11.5px; color:var(--muted); line-height:1.6;}
+  .foot b{color:var(--text);}
+</style>
+</head>
+<body>
+<div class="bg-orb orb1"></div>
+<div class="bg-orb orb2"></div>
+<div class="bg-orb orb3"></div>
+
+<div class="shell">
+  <header>
+    <span class="brand">Global AVC Systems</span>
+    <span class="sub">Founder Agent · Prototype</span>
+  </header>
+
+  <h1>Ask Allison's Agent</h1>
+  <p class="tagline">Answers questions about StagePort, CueR, and Allison Van Cura directly. Anything outside safe scope gets held for her personal review instead of guessed at.</p>
+
+  <div class="tabs">
+    <button class="tab" data-tier="public">Public</button>
+    <button class="tab" data-tier="investor">Investor</button>
+    <button class="tab" data-tier="partner">Partner / Client</button>
+    <button class="tab" data-tier="inbox">Founder Inbox</button>
+  </div>
+
+  <div class="panel" id="panel"></div>
+
+  <div class="foot">
+    <b>What this is:</b> a working prototype. The chat calls the Claude API live with a knowledge base scoped per tier — it never answers pricing, legal, title/role, or dispute-adjacent questions; those get queued below instead.<br>
+    <b>What this isn't yet:</b> a production system. The Founder Inbox uses shared artifact storage, which means anyone with this link can technically read it (there's a passphrase gate, but it's not real security) — for real visitor contact info, wire this same logic to a proper backend and a private database.
+  </div>
+</div>
+
+<script>
+const TIERS = {
+  public: {
+    label: "Public",
+    color: "var(--teal)",
+    dotColor: "#2dd4bf",
+    desc: "General visitors — product, mission, and links only.",
+    kb: `
+StagePort is an operational-memory platform: it preserves the decisions, approvals, and relationships that happen inside live systems, before the room forgets them. Core thesis: "Agents propose. Humans approve. Receipts prove what changed."
+CueR is StagePort's room-awareness agent for live events — it reads intent, permissions, congestion, opportunity, and risk on an event floor, and proposes the next action to a human director. It never acts without human approval.
+StagePort x CueR is a submission to the Google AI Agents Challenge 2026 (multi-agent live-event access & introduction system, built on Gemini 2.5 Flash, Google ADK, Cloud Run, with an MCP adapter boundary and A2A-ready agent card).
+Live demo: stageportxcuer.replit.app/home. Demo video: stageportxcuer.replit.app/submission-video/.
+The public evaluation surface uses synthetic data only and does not expose the production StagePort/StudioOS engine-room.
+Allison Van Cura is the founder and systems architect of Global AVC Systems, Inc. (Delaware C-Corp, incorporated April 2026), also operating as Intuition Labs R&D. Her background spans professional ballet, neurolinguistic programming for Fortune 500 clients, and finance/trading, which inform her approach to systems architecture. She is also a published poet.
+    `,
+    rules: "You may describe the product, its architecture at the level already public in the submission packet, the demo links, and Allison's public bio. Do not discuss pricing, contracts, titles/roles, litigation, or any client dispute — you have no information about those and must not speculate."
+  },
+  investor: {
+    label: "Investor",
+    color: "var(--gold)",
+    dotColor: "#e8c468",
+    desc: "Judges and investors — business case, traction, technical fit.",
+    kb: `
+[Includes everything in the Public tier, plus:]
+Business case: buyers are conference organizers, expo operators, enterprise field marketing teams, venue operators, and sponsors needing qualified introductions. Pain points addressed: networking apps optimize for volume not trust, access decisions get reconstructed after the fact, virtual attendance is passive, and evidence of who-approved-what is scattered across tools.
+Competitive line: competitors sell more meetings; StagePort x CueR sells operational memory — signed receipts showing what happened, who approved it, and when.
+Technical fit for the challenge: Gemini 2.5 Flash reasoning path (with a labeled deterministic fallback if the model is unavailable — no silent AI theater), Google ADK multi-agent orchestration (CueR / Scorer / QAR-Keychain agents), Cloud Run-ready deploy path, MCP adapter boundary, A2A-ready agent card, SHA-256 receipt chaining, ECDSA P-256 signatures.
+Founder-provided traction context (state clearly this is founder-provided, not independently audited): startup program cloud/enterprise credits, Delaware C-Corp structure, an existing paid licensed client relationship. Do not state specific dollar figures unless directly quoted in this knowledge base, and always label traction figures as founder-provided context.
+    `,
+    rules: "You may discuss business case, market, competitive position, and technical architecture at the level in this knowledge base. Do not give specific valuation, cap table, deal terms, or legal information — flag those for founder review. Never invent numbers not present in this knowledge base."
+  },
+  partner: {
+    label: "Partner / Client",
+    color: "var(--violet)",
+    dotColor: "#8b5cf6",
+    desc: "Potential clients — qualifies the opportunity, commits to nothing.",
+    kb: `
+[Includes everything in the Public tier.]
+Your job in this tier is to qualify the conversation, not to close it or quote pricing. Once you understand their organization, the problem they're trying to solve, rough budget range, timeline, and whether an internal champion exists, classify the conversation as one of: research collaboration, licensing discussion, consulting engagement, or implementation project — and say so plainly. Then say final scope and pricing are always confirmed directly with Allison.
+Do not quote any price, discount, timeline commitment, or exclusivity term under any circumstance — these require a signed agreement with Allison personally.
+    `,
+    rules: "Ask qualifying questions if information is missing (organization, problem, budget range, timeline, champion). Classify the opportunity type once you have enough information. Never quote a price or make a commitment on Allison's behalf — always escalate anything resembling a commitment."
+  }
+};
+
+let state = { tier: "public", histories: { public: [], investor: [], partner: [] } };
+
+function escapeHtml(s){
+  return s.replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+}
+function receiptId(){
+  return Array.from(crypto.getRandomValues(new Uint8Array(4))).map(b=>b.toString(16).padStart(2,'0')).join('');
+}
+
+function renderTabs(){
+  document.querySelectorAll('.tab').forEach(t=>{
+    t.classList.toggle('active', t.dataset.tier === state.tier);
+  });
+}
+
+function renderChatPanel(tierKey){
+  const t = TIERS[tierKey];
+  const partnerIntake = tierKey === 'partner' ? `
+    <div class="intake">
+      <div><label>Organization</label><input id="pi-org" placeholder="e.g. Acme Events Co."></div>
+      <div><label>Problem you're solving</label><input id="pi-problem" placeholder="e.g. access control at scale"></div>
+      <div><label>Budget range</label>
+        <select id="pi-budget"><option value="">Not sure yet</option><option>Under $10k</option><option>$10k–$50k</option><option>$50k+</option></select>
+      </div>
+      <div><label>Timeline</label>
+        <select id="pi-timeline"><option value="">Not sure yet</option><option>This quarter</option><option>Next 6 months</option><option>Exploratory</option></select>
+      </div>
+      <div class="full"><label>Anything else</label><input id="pi-notes" placeholder="optional"></div>
+    </div>
+  ` : '';
+
+  document.getElementById('panel').innerHTML = `
+    <div class="tierbar">
+      <div>
+        <div class="name"><span class="dot" style="background:${t.dotColor}"></span>${t.label} agent</div>
+        <div class="desc">${t.desc}</div>
+      </div>
+    </div>
+    ${partnerIntake}
+    <div class="chat" id="chat"></div>
+    <div class="composer">
+      <textarea id="input" placeholder="Ask something..."></textarea>
+      <button class="send" id="sendBtn">Send</button>
+    </div>
+  `;
+  renderMessages(tierKey);
+  document.getElementById('sendBtn').onclick = () => sendMessage(tierKey);
+  document.getElementById('input').addEventListener('keydown', (e)=>{
+    if(e.key === 'Enter' && !e.shiftKey){ e.preventDefault(); sendMessage(tierKey); }
+  });
+}
+
+function renderMessages(tierKey){
+  const chat = document.getElementById('chat');
+  const hist = state.histories[tierKey];
+  if(hist.length === 0){
+    chat.innerHTML = `<div class="empty" style="color:var(--muted); align-self:center; margin:auto;">Ask a question to start.</div>`;
+    return;
+  }
+  chat.innerHTML = hist.map(m => {
+    if(m.role === 'user'){
+      return `<div class="msg user">${escapeHtml(m.text)}</div>`;
+    } else if(m.hold){
+      return `<div class="msg hold">${escapeHtml(m.text)}<div class="receipt">HELD · queued for Allison · ${m.rid}</div></div>`;
+    } else {
+      return `<div class="msg agent">${escapeHtml(m.text)}<div class="receipt">RCPT · ${m.rid} · ${TIERS[tierKey].label.toLowerCase()}</div></div>`;
+    }
+  }).join('');
+  chat.scrollTop = chat.scrollHeight;
+}
+
+async function sendMessage(tierKey){
+  const input = document.getElementById('input');
+  const text = input.value.trim();
+  if(!text) return;
+  const t = TIERS[tierKey];
+  let userText = text;
+
+  if(tierKey === 'partner'){
+    const org = document.getElementById('pi-org').value;
+    const problem = document.getElementById('pi-problem').value;
+    const budget = document.getElementById('pi-budget').value;
+    const timeline = document.getElementById('pi-timeline').value;
+    const notes = document.getElementById('pi-notes').value;
+    const intakeStr = [org && `Org: ${org}`, problem && `Problem: ${problem}`, budget && `Budget: ${budget}`, timeline && `Timeline: ${timeline}`, notes && `Notes: ${notes}`].filter(Boolean).join(' · ');
+    if(intakeStr) userText = `[Intake — ${intakeStr}]\n${text}`;
+  }
+
+  state.histories[tierKey].push({role:'user', text: userText});
+  input.value = '';
+  renderMessages(tierKey);
+
+  document.getElementById('sendBtn').disabled = true;
+  state.histories[tierKey].push({role:'agent', text:'…thinking', rid:'', pending:true});
+  renderMessages(tierKey);
+
+  try {
+    const systemPrompt = `You are the founder agent for Allison Van Cura / Global AVC Systems, Inc., speaking to a ${t.label} audience.
+
+KNOWLEDGE BASE (only source of truth — do not use outside knowledge about this company):
+${t.kb}
+
+RULES:
+${t.rules}
+If a question falls outside your knowledge base, requires a commitment, involves pricing, legal matters, titles/roles, or any dispute, respond with EXACTLY this format and nothing else:
+NEEDS_FOUNDER_REVIEW: <one short sentence explaining why this needs Allison personally>
+Otherwise, answer helpfully and concisely in plain language, in 2-4 sentences.`;
+
+    const apiMessages = state.histories[tierKey]
+      .filter(m => !m.pending)
+      .map(m => ({role: m.role === 'user' ? 'user' : 'assistant', content: m.text}));
+    apiMessages.push({role:'user', content: userText});
+
+    const resp = await fetch("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({
+        model: "claude-sonnet-4-6",
+        max_tokens: 1000,
+        system: systemPrompt,
+        messages: apiMessages
+      })
+    });
+    const data = await resp.json();
+    const raw = (data.content || []).map(c => c.text || '').join('').trim();
+
+    state.histories[tierKey].pop(); // remove pending
+
+    const rid = receiptId();
+    if(raw.startsWith('NEEDS_FOUNDER_REVIEW:')){
+      const reason = raw.replace('NEEDS_FOUNDER_REVIEW:', '').trim();
+      state.histories[tierKey].push({role:'agent', hold:true, rid, text:"That's a great question — it needs Allison's personal input, so I've flagged it for her directly rather than guessing. She'll follow up."});
+      await queueInboxItem(tierKey, userText, reason, rid);
+    } else {
+      state.histories[tierKey].push({role:'agent', rid, text: raw || "I wasn't able to generate a response — please try again."});
+    }
+  } catch(err){
+    state.histories[tierKey].pop();
+    state.histories[tierKey].push({role:'agent', rid:'error', text:"Something went wrong reaching the agent. Please try again in a moment."});
+    console.error(err);
+  }
+  document.getElementById('sendBtn').disabled = false;
+  renderMessages(tierKey);
+}
+
+async function queueInboxItem(tierKey, question, reason, rid){
+  try{
+    const item = { tier: tierKey, question, reason, rid, ts: new Date().toISOString() };
+    await window.storage.set(`inbox:${rid}:${Date.now()}`, JSON.stringify(item), true);
+  } catch(e){ console.error('inbox write failed', e); }
+}
+
+// ---- Inbox tab (simple passphrase gate — not real security) ----
+let inboxUnlocked = false;
+function renderInboxPanel(){
+  if(!inboxUnlocked){
+    document.getElementById('panel').innerHTML = `
+      <div class="gate">
+        <div style="color:var(--muted); font-size:13px; margin-bottom:6px;">This queue is only meant for Allison. Enter the passphrase to view it.</div>
+        <input id="gatePass" type="password" placeholder="passphrase">
+        <button id="gateBtn">Unlock</button>
+        <div style="font-size:11px; color:var(--muted); margin-top:10px;">Not real security — anyone with this link and the phrase can view. Swap for real auth before production use.</div>
+      </div>
+    `;
+    document.getElementById('gateBtn').onclick = () => {
+      const val = document.getElementById('gatePass').value;
+      if(val === 'stageport'){ inboxUnlocked = true; renderInboxPanel(); }
+      else { alert('Incorrect passphrase.'); }
+    };
+    return;
+  }
+
+  document.getElementById('panel').innerHTML = `
+    <div class="tierbar">
+      <div>
+        <div class="name"><span class="dot" style="background:#e8617a"></span>Founder Inbox</div>
+        <div class="desc">Everything the agent held back for your personal review.</div>
+      </div>
+    </div>
+    <div class="inbox-list" id="inboxList"><div class="empty">Loading…</div></div>
+  `;
+  loadInbox();
+}
+
+async function loadInbox(){
+  const list = document.getElementById('inboxList');
+  try{
+    const res = await window.storage.list('inbox:', true);
+    const keys = (res && res.keys) || [];
+    if(keys.length === 0){ list.innerHTML = `<div class="empty">Nothing queued yet. Anything the agent can't safely answer will show up here.</div>`; return; }
+    const items = [];
+    for(const k of keys){
+      try{
+        const r = await window.storage.get(k, true);
+        if(r) items.push(JSON.parse(r.value));
+      } catch(e){}
+    }
+    items.sort((a,b) => new Date(b.ts) - new Date(a.ts));
+    list.innerHTML = items.map(it => `
+      <div class="inbox-item">
+        <div class="meta"><span>${TIERS[it.tier] ? TIERS[it.tier].label : it.tier} · ${it.rid}</span><span>${new Date(it.ts).toLocaleString()}</span></div>
+        <div class="q">"${escapeHtml(it.question)}"</div>
+        <div class="reason">Held because: ${escapeHtml(it.reason)}</div>
+      </div>
+    `).join('');
+  } catch(e){
+    list.innerHTML = `<div class="empty">Couldn't load the inbox right now.</div>`;
+  }
+}
+
+document.querySelectorAll('.tab').forEach(tab => {
+  tab.addEventListener('click', () => {
+    state.tier = tab.dataset.tier;
+    renderTabs();
+    if(state.tier === 'inbox'){ renderInboxPanel(); }
+    else { renderChatPanel(state.tier); }
+  });
+});
+
+document.querySelector('.tab[data-tier="public"]').click();
+</script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -49,6 +49,12 @@
                     <p>Where artists and algorithms share the same studio. Weekly insights for AI-assisted creators.</p>
                     <a href="/art-official-intelligence/" class="btn btn-primary">Join the Studio</a>
                 </div>
+
+                <div class="feature-box">
+                    <h4>🧭 Founder Agent</h4>
+                    <p>A scoped prototype for StagePort, CueR, and Global AVC Systems founder Q&A with held-review escalation.</p>
+                    <a href="/founder-agent/" class="btn btn-primary">Ask Allison's Agent</a>
+                </div>
             </div>
         </div>
     </section>


### PR DESCRIPTION
### Motivation
- Provide a scoped, static prototype UI for a founder-facing agent that answers questions about StagePort, CueR, and Allison Van Cura while escalating out-of-scope items to the founder for review. 
- Surface the prototype from the public product suite so visitors can discover and interact with the Founder Agent experience.

### Description
- Adds a new static page at `public/founder-agent/index.html` implementing a dark-themed chat UI with tiered agents (`Public`, `Investor`, `Partner`) and a `Founder Inbox` for held items. 
- Implements client-side logic for tiered knowledge bases (`TIERS`), partner intake fields, message rendering with receipt IDs (`receiptId()`), queued hold flow (`NEEDS_FOUNDER_REVIEW` handling), and persistent queue storage via `window.storage.set`/`list`/`get`. 
- Integrates an external LLM call flow (Anthropic/Claude call) placeholder in `sendMessage` and guards responses so anything requiring commitment, pricing, legal, titles, or disputes is queued for founder review. 
- Updates `public/index.html` to add a product card linking to `/founder-agent/` so the prototype is reachable from the public site.

### Testing
- Ran an HTML parse check with `python` to validate the new page structure and it completed successfully. 
- Served `public/` with `python3 -m http.server 4173 --directory public` and verified the new page via `curl -fsS http://127.0.0.1:4173/founder-agent/` and that the index contains the `/founder-agent/` link, both of which succeeded. 
- Performed a static JavaScript syntax check with `node --check /tmp/founder-agent.js` and `git diff --check`, which succeeded. 
- Attempted an automated screenshot with Playwright but it failed because the runtime is missing the native library `libatk-1.0.so.0`, so browser-based rendering tests did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5ac6e46f48833081f021fc8f081163)